### PR TITLE
feat: waku object updateStore

### DIFF
--- a/src/lib/adapters/firebase/index.ts
+++ b/src/lib/adapters/firebase/index.ts
@@ -301,12 +301,12 @@ export default class FirebaseAdapter implements Adapter {
 		setDoc(daiDoc, daiData, { merge: true })
 	}
 
-	updateStore(
+	async updateStore(
 		wallet: HDNodeWallet,
 		objectId: string,
 		instanceId: string,
 		updater: (state: unknown) => unknown,
-	): void {
+	): Promise<void> {
 		const { address } = wallet
 		const key = objectKey(objectId, instanceId)
 		const objectDb = doc(db, `users/${address}/objects/${key}`)

--- a/src/lib/adapters/firebase/schemas.ts
+++ b/src/lib/adapters/firebase/schemas.ts
@@ -46,3 +46,6 @@ export const ChatDbSchema = z.object({
 	name: z.string().optional(),
 })
 export type ChatDb = z.infer<typeof ChatDbSchema>
+
+export const ObjectDbSchema = z.unknown()
+export type ObjectDb = z.infer<typeof UserDbSchema>

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -33,7 +33,7 @@ export interface Adapter {
 		objectId: string,
 		instanceId: string,
 		updater: (state: unknown) => unknown,
-	): void
+	): Promise<void>
 }
 
 const DEFAULT_ADAPTER = 'firebase'

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -27,6 +27,13 @@ export interface Adapter {
 
 	uploadPicture(picture: string): Promise<string>
 	getPicture(cid: string): string
+
+	updateStore(
+		wallet: HDNodeWallet,
+		objectId: string,
+		instanceId: string,
+		updater: (state: unknown) => unknown,
+	): void
 }
 
 const DEFAULT_ADAPTER = 'firebase'

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -86,6 +86,7 @@ async function readObjectStore(waku: LightNode, address: string): Promise<Object
 	return {
 		loading: false,
 		objects: new Map(objectStoreData),
+		lastUpdated: Date.now(),
 	}
 }
 
@@ -293,4 +294,16 @@ export default class WakuAdapter implements Adapter {
 	getPicture(cid: string): string {
 		return `${IPFS_GATEWAY}/${cid}`
 	}
+
+	updateStore(
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		wallet: HDNodeWallet,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		objectId: string,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		instanceId: string,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		updater: (state: unknown) => unknown,
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+	): void {}
 }

--- a/src/lib/objects/hello-world/hello-world-receiver.svelte
+++ b/src/lib/objects/hello-world/hello-world-receiver.svelte
@@ -1,19 +1,22 @@
 <script lang="ts">
 	import Button from '$lib/components/button.svelte'
 
+	export let instanceId: string
 	export let name: string | undefined
 	export let ownName: string
 	export let send: (data: unknown) => Promise<void>
+	export let updateStore: (updater: (state: unknown) => unknown) => void
 
 	async function sendName() {
+		updateStore(() => ({ name: ownName }))
 		await send({ name: ownName })
 	}
 </script>
 
 {#if name}
-	Sent 'Hello from {name}'
+	{instanceId}: Sent 'Hello from {name}'
 {:else}
-	<Button variant="strong" on:click={sendName}>Send Hello!</Button>
+	<Button variant="strong" on:click={sendName}>{instanceId}: Send Hello from {ownName}!</Button>
 {/if}
 
 <style lang="scss">

--- a/src/lib/objects/hello-world/hello-world-sender.svelte
+++ b/src/lib/objects/hello-world/hello-world-sender.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+	export let instanceId: string
 	export let name: string | undefined
 </script>
 
 {#if name}
-	Hello from {name}
+	{instanceId}: Hello from {name}
 {:else}
-	Hello World
+	{instanceId}: Hello World
 {/if}
 
 <style lang="scss">

--- a/src/lib/objects/hello-world/hello-world.svelte
+++ b/src/lib/objects/hello-world/hello-world.svelte
@@ -13,7 +13,13 @@
 </script>
 
 {#if address === message?.fromAddress}
-	<HelloWorldSender name={helloWorldStore?.name} />
+	<HelloWorldSender instanceId={message.instanceId} name={helloWorldStore?.name} />
 {:else}
-	<HelloWorldReceiver name={helloWorldStore?.name} send={args.send} ownName={args.name} />
+	<HelloWorldReceiver
+		instanceId={message.instanceId}
+		name={helloWorldStore?.name}
+		send={args.send}
+		updateStore={args.updateStore}
+		ownName={args.name}
+	/>
 {/if}

--- a/src/lib/objects/hello-world/index.ts
+++ b/src/lib/objects/hello-world/index.ts
@@ -1,5 +1,18 @@
+import type { WakuObjectDescriptor } from '..'
+import HelloWorld from './hello-world.svelte'
+
 export interface HelloWorldStore {
 	name?: string
 }
 
 export const HELLO_WORLD_OBJECT_ID = 'hello-world'
+
+export const helloWorldDescriptor: WakuObjectDescriptor = {
+	objectId: HELLO_WORLD_OBJECT_ID,
+
+	wakuObject: HelloWorld,
+
+	onMessage: (store, message) => {
+		return message.data
+	},
+}

--- a/src/lib/objects/hello-world/index.ts
+++ b/src/lib/objects/hello-world/index.ts
@@ -1,4 +1,5 @@
 export interface HelloWorldStore {
 	name?: string
 }
+
 export const HELLO_WORLD_OBJECT_ID = 'hello-world'

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -1,3 +1,6 @@
+import type { DataMessage } from '$lib/stores/chat'
+import type { ComponentType } from 'svelte'
+
 export interface WakuObjectArgs {
 	readonly address: string
 	readonly name: string
@@ -6,4 +9,11 @@ export interface WakuObjectArgs {
 	updateStore: (updater: (state: unknown) => unknown) => void
 
 	send: (data: unknown) => Promise<void>
+}
+
+interface WakuObjectDescriptor {
+	readonly objectId: string
+	readonly wakuObject: ComponentType
+	onMessage?: (store: unknown, message: DataMessage) => unknown
+	// TODO onTransaction: (store: unknown, transaction: Transaction) => unknown
 }

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -1,6 +1,9 @@
 export interface WakuObjectArgs {
-	address: string
-	name: string
-	store: unknown
+	readonly address: string
+	readonly name: string
+
+	readonly store: unknown
+	updateStore: (updater: (state: unknown) => unknown) => void
+
 	send: (data: unknown) => Promise<void>
 }

--- a/src/lib/objects/lookup.ts
+++ b/src/lib/objects/lookup.ts
@@ -1,0 +1,10 @@
+import type { WakuObjectDescriptor } from '.'
+import { HELLO_WORLD_OBJECT_ID, helloWorldDescriptor } from './hello-world'
+
+const wakuObjectMap: Map<string, WakuObjectDescriptor> = new Map([
+	[HELLO_WORLD_OBJECT_ID, helloWorldDescriptor],
+])
+
+export function lookup(objectId: string): WakuObjectDescriptor | undefined {
+	return wakuObjectMap.get(objectId)
+}

--- a/src/lib/objects/waku-object.svelte
+++ b/src/lib/objects/waku-object.svelte
@@ -32,11 +32,16 @@
 	let args: WakuObjectArgs
 	$: args = {
 		name,
-		store,
 		address,
+		store,
+		updateStore: (updater) => {
+			$objectStore.objects.set(objectKey(message.objectId, message.instanceId), updater(store))
+		},
 		send: (data: unknown) =>
 			adapter.sendData(wallet, chatId, message.objectId, message.instanceId, data),
 	}
+
+	$: console.debug({ message, args, $objectStore })
 </script>
 
 <div

--- a/src/lib/objects/waku-object.svelte
+++ b/src/lib/objects/waku-object.svelte
@@ -33,8 +33,6 @@
 		send: (data: unknown) =>
 			adapter.sendData(wallet, chatId, message.objectId, message.instanceId, data),
 	}
-
-	$: console.debug({ message, args, $objectStore })
 </script>
 
 <div

--- a/src/lib/objects/waku-object.svelte
+++ b/src/lib/objects/waku-object.svelte
@@ -1,23 +1,16 @@
 <script lang="ts">
 	import type { DataMessage } from '$lib/stores/chat'
 	import { walletStore } from '$lib/stores/wallet'
-	import { HELLO_WORLD_OBJECT_ID } from './hello-world'
-	import HelloWorld from './hello-world/hello-world.svelte'
 	import { objectKey, objectStore } from '$lib/stores/objects'
 	import adapter from '$lib/adapters'
 	import { page } from '$app/stores'
 	import { profile } from '$lib/stores/profile'
 	import type { WakuObjectArgs } from '.'
+	import { lookup } from './lookup'
 
 	export let message: DataMessage
 
-	function selectComponent() {
-		switch (message.objectId) {
-			case HELLO_WORLD_OBJECT_ID:
-				return HelloWorld
-		}
-	}
-	const component = selectComponent()
+	const component = lookup(message.objectId)?.wakuObject
 
 	let store: unknown
 	$: store = $objectStore.objects.get(objectKey(message.objectId, message.instanceId))
@@ -35,7 +28,7 @@
 		address,
 		store,
 		updateStore: (updater) => {
-			$objectStore.objects.set(objectKey(message.objectId, message.instanceId), updater(store))
+			adapter.updateStore(wallet, message.objectId, message.instanceId, updater)
 		},
 		send: (data: unknown) =>
 			adapter.sendData(wallet, chatId, message.objectId, message.instanceId, data),

--- a/src/lib/stores/objects.ts
+++ b/src/lib/stores/objects.ts
@@ -2,6 +2,7 @@ import { writable, type Writable } from 'svelte/store'
 
 export interface ObjectState {
 	loading: boolean
+	lastUpdated: number
 	objects: Map<string, unknown>
 	error?: Error
 }
@@ -10,11 +11,15 @@ export interface ObjectState {
 interface ObjectStore extends Writable<ObjectState> {}
 
 export function objectKey(objectId: string, instanceId: string): string {
-	return `${objectId}/${instanceId}`
+	return `${objectId}:${instanceId}`
 }
 
 export function createObjectStore(): ObjectStore {
-	const store = writable<ObjectState>({ loading: true, objects: new Map<string, unknown>() })
+	const store = writable<ObjectState>({
+		loading: true,
+		objects: new Map<string, unknown>(),
+		lastUpdated: 0,
+	})
 	return {
 		...store,
 	}


### PR DESCRIPTION
This PR adds the functionality to update the object store in a generic way when an external event happens. Currently it's only updated when there is a data message coming in, but later more events (e.g. transactions) can be added.

The idea is that each object defines a `WakuObjectDescriptor` which may define functionality what should happen when an external event happens (e.g. `onMessage`). I realized that in order to keep the data flow uni-directional the update needs to happen through the adapter and that will update the store. I attached a small diagram about this (which require more work I admit :smile:  ).

Known issues: 
- the firebase update checks the `timestamp` of a message to see if it has been applied for the store already. However this may introduce inconsistencies. For example if there are two events happening in about the same time on different nodes then when merging local updates may be visible and then remote updates may be ignored.
- the firebase update reads the current state of the object store to pass it as an argument to the `updater` function and then using the return value to update the Firebase store and then the objectstore will be updated in the callback of the subscription of the Firebase store. This makes it difficult to follow the code and most likely is suboptimal.

![Untitled Diagram drawio](https://github.com/logos-innovation-lab/waku-objects-playground/assets/230163/b2c7133b-afa6-40ac-9cf2-8a7b70180e88)
