### PR TITLE
feat: add address to onMessage

### DIFF
--- a/src/lib/adapters/firebase/index.ts
+++ b/src/lib/adapters/firebase/index.ts
@@ -137,7 +137,7 @@ export default class FirebaseAdapter implements Adapter {
 									wakuObjectStore.lastUpdated < message.timestamp
 								) {
 									const objects = wakuObjectStore.objects
-									const newStore = descriptor.onMessage(objects.get(key), message)
+									const newStore = descriptor.onMessage(address, objects.get(key), message)
 
 									const objectDb = doc(db, `users/${address}/objects/${key}`)
 									// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -187,7 +187,7 @@ export default class WakuAdapter implements Adapter {
 						wakuObjectStore.lastUpdated < chatMessage.timestamp
 					) {
 						const objects = wakuObjectStore.objects
-						const newStore = descriptor.onMessage(objects.get(key), chatMessage)
+						const newStore = descriptor.onMessage(address, objects.get(key), chatMessage)
 						const newObjects = new Map(objects)
 						newObjects.set(key, newStore)
 						objectStore.update((state) => ({

--- a/src/lib/objects/hello-world/index.ts
+++ b/src/lib/objects/hello-world/index.ts
@@ -12,7 +12,7 @@ export const helloWorldDescriptor: WakuObjectDescriptor = {
 
 	wakuObject: HelloWorld,
 
-	onMessage: (store, message) => {
+	onMessage: (address, store, message) => {
 		return message.data
 	},
 }

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -14,6 +14,6 @@ export interface WakuObjectArgs {
 interface WakuObjectDescriptor {
 	readonly objectId: string
 	readonly wakuObject: ComponentType
-	onMessage?: (store: unknown, message: DataMessage) => unknown
+	onMessage?: (address: string, store: unknown, message: DataMessage) => unknown
 	// TODO onTransaction: (store: unknown, transaction: Transaction) => unknown
 }


### PR DESCRIPTION
This PR addresses one of the issues from #105, that there was no way in the `onMessage` to differentiate if a message originated locally or remotely. By adding an `address` field that contains the address of the user it is possible to compare this value to the recipient of the message.