### PR TITLE
feat: improve typing by eliminating unknown types

### DIFF
--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -2,23 +2,29 @@ import type { Token } from '$lib/stores/balances'
 import type { DataMessage } from '$lib/stores/chat'
 import type { ComponentType } from 'svelte'
 
-export interface WakuObjectArgs {
+export interface WakuObjectArgs<StoreType = unknown, DataMessageType = unknown> {
 	readonly address: string
 	readonly name: string
 
-	readonly store: unknown
-	updateStore: (updater: (state: unknown) => unknown) => void
+	readonly store: StoreType
+	updateStore: (updater: (state: StoreType) => StoreType) => void
 
-	send: (data: unknown) => Promise<void>
+	send: (data: DataMessageType) => Promise<void>
 	sendTransaction?: (to: string, token: Token, fee: Token) => Promise<string>
 	estimateTransaction?: (to: string, token: Token) => Promise<Token>
 	onViewChange?: (view: string) => void
 }
 
+type WakuStoreType = unknown
+
 interface WakuObjectDescriptor {
 	readonly objectId: string
 	readonly wakuObject: ComponentType
 	readonly standalone?: ComponentType
-	onMessage?: (address: string, store: unknown, message: DataMessage) => unknown
+	onMessage?: (
+		address: string,
+		store: WakuStoreType,
+		message: DataMessage<DataMessageType>,
+	) => WakuStoreType
 	// TODO onTransaction: (store: unknown, transaction: Transaction) => unknown
 }

--- a/src/lib/objects/send_transaction/chat.svelte
+++ b/src/lib/objects/send_transaction/chat.svelte
@@ -6,8 +6,8 @@
 	import { formatTokenAmount } from '$lib/utils/format'
 	import ChatMessage from '$lib/components/chat-message.svelte'
 
-	export let message: DataMessage
-	export let args: WakuObjectArgs
+	export let message: DataMessage<MessageDataSend>
+	export let args: WakuObjectArgs<MessageDataSend, MessageDataSend>
 
 	// Don't need to do this, everything should be in the message itself
 	let store: SendTransaction

--- a/src/lib/objects/send_transaction/standalone.svelte
+++ b/src/lib/objects/send_transaction/standalone.svelte
@@ -9,12 +9,16 @@
 	import ArrowRight from '$lib/components/icons/arrow-right.svelte'
 	import { formatAddress, formatTokenAmount } from '$lib/utils/format'
 	import type { WakuObjectArgs } from '..'
-	import { SendTransactionStandaloneSchema, type SendTransactionStandalone } from './schemas'
+	import {
+		SendTransactionStandaloneSchema,
+		type SendTransactionStandalone,
+		type MessageDataSend,
+	} from './schemas'
 	import type { Token } from '../schemas'
 	import CaretDown from '$lib/components/icons/caret-down.svelte'
 	import WarningAltFilled from '$lib/components/icons/warning-alt-filled.svelte'
 
-	export let args: WakuObjectArgs
+	export let args: WakuObjectArgs<MessageDataSend, MessageDataSend>
 
 	let store: SendTransactionStandalone
 	$: {

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -8,13 +8,13 @@ export interface UserMessage {
 	text: string
 }
 
-export interface DataMessage {
+export interface DataMessage<T = unknown> {
 	type: 'data'
 	timestamp: number
 	fromAddress: string
 	objectId: string
 	instanceId: string
-	data?: unknown
+	data?: T
 }
 
 export type Message = UserMessage | DataMessage


### PR DESCRIPTION
It bothered me that there were a lot of `unknown`s on the waku interfaces, sometimes even multiple different objects were `unknown`. This is an attempt to improve the situation.