### PR TITLE
feat: add transaction support for waku adapter

### DIFF
--- a/src/lib/adapters/firebase/index.ts
+++ b/src/lib/adapters/firebase/index.ts
@@ -279,7 +279,7 @@ export default class FirebaseAdapter implements Adapter {
 	/**
 	 * THIS IS JUST FOR DEV PURPOSES
 	 */
-	initializeBalances(wallet: HDNodeWallet): void {
+	async initializeBalances(wallet: HDNodeWallet): Promise<void> {
 		const { address } = wallet
 
 		if (!address) throw new Error('Address is missing')

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -37,6 +37,9 @@ export interface Adapter {
 	): Promise<void>
 	sendTransaction(wallet: HDNodeWallet, to: string, token: Token, fee: Token): Promise<string>
 	estimateTransaction(wallet: HDNodeWallet, to: string, token: Token): Promise<Token>
+
+	// THIS IS JUST FOR DEV PURPOSES
+	initializeBalances(wallet: HDNodeWallet): Promise<void>
 }
 
 const DEFAULT_ADAPTER = 'firebase'

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -19,7 +19,8 @@ import { ipfs, IPFS_GATEWAY } from '../firebase/connections'
 import { get } from 'svelte/store'
 import { objectStore, type ObjectState, objectKey } from '$lib/stores/objects'
 import { lookup } from '$lib/objects/lookup'
-import type { Token } from '$lib/stores/balances'
+import { balanceStore, type BalanceState, type Token } from '$lib/stores/balances'
+import { TokenDbSchema, type TokenDb } from '../firebase/schemas'
 
 function createChat(chatId: string, user: User, address: string): string {
 	chats.update((state) => {
@@ -118,6 +119,33 @@ async function storeObjectStore(waku: LightNode, address: string, objectStore: O
 	await storeDocument(waku, 'objects', address, Array.from(objectStore.objects))
 }
 
+async function readBalances(waku: LightNode, address: string): Promise<BalanceState> {
+	const balancesRaw = (await readLatestDocument(waku, 'balances', address)) as TokenDb[] | undefined
+	const balances: Token[] = []
+	if (balancesRaw) {
+		balancesRaw.forEach((balanceRaw) => {
+			const balance = TokenDbSchema.safeParse(balanceRaw)
+			if (balance.success) {
+				balances.push(balance.data)
+			}
+		})
+	}
+
+	return {
+		loading: false,
+		balances,
+	}
+}
+
+async function storeBalances(waku: LightNode, address: string, balanceState: BalanceState) {
+	return await storeDocument(
+		waku,
+		'balances',
+		address,
+		balanceState.balances.map((token) => ({ ...token, amount: token.amount.toString() })),
+	)
+}
+
 /*
  * Temporary helper function to read all users from the waku store, so that contacts are discoverable.
  * This functionality can be removed once the invite system is working.
@@ -214,6 +242,17 @@ export default class WakuAdapter implements Adapter {
 			await storeObjectStore(adapter.waku, address, objects)
 		})
 		this.subscriptions.push(subscribeObjectStore)
+
+		const balanceState = await readBalances(this.waku, address)
+		balanceStore.set(balanceState)
+
+		const subscribeBalanceStore = balanceStore.subscribe(async (balanceState) => {
+			if (!adapter.waku) {
+				return
+			}
+			await storeBalances(adapter.waku, address, balanceState)
+		})
+		this.subscriptions.push(subscribeBalanceStore)
 	}
 
 	async onLogOut() {
@@ -342,16 +381,128 @@ export default class WakuAdapter implements Adapter {
 		await storeObjectStore(this.waku, wallet.address, updatedObjectStore)
 	}
 
-	sendTransaction(wallet: HDNodeWallet, to: string, token: Token, fee: Token): Promise<string> {
-		console.log('Method not implemented.', { wallet, to, token, fee })
-		throw new Error('Method not implemented.')
-	}
-	estimateTransaction(wallet: HDNodeWallet, to: string, token: Token): Promise<Token> {
-		console.log('Method not implemented.', {
-			wallet,
+	async sendTransaction(
+		wallet: HDNodeWallet,
+		to: string,
+		token: Token,
+		fee: Token,
+	): Promise<string> {
+		const { address } = wallet
+
+		if (!address) throw new Error('Address is missing')
+
+		if (!this.waku) {
+			throw 'no waku'
+		}
+
+		const tx = {
+			from: address,
 			to,
-			token,
+			token: {
+				amount: token.amount.toString(),
+				name: token.name,
+				symbol: token.symbol,
+				decimals: token.decimals,
+			},
+			timestamp: Date.now(),
+			fee: {
+				amount: fee.amount.toString(),
+				symbol: fee.symbol,
+				name: fee.name,
+				decimals: fee.decimals,
+			},
+		}
+
+		// Update balances
+		const balanceFromDoc = get(balanceStore)
+		const balanceToDoc = await readBalances(this.waku, to)
+		const balanceFrom = balanceFromDoc.balances.find((balance) => balance.symbol === token.symbol)
+		const balanceTo = balanceToDoc.balances.find((balance) => balance.symbol === token.symbol)
+		const feeFrom = balanceFromDoc.balances.find((balance) => balance.symbol === fee.symbol)
+		if (!balanceFrom || !balanceTo || !feeFrom) throw new Error('Balance not found')
+
+		if (balanceFrom.amount - token.amount >= 0 && feeFrom.amount - fee.amount >= 0) {
+			balanceStore.update((prevState) => ({
+				...prevState,
+				balances: prevState.balances.map((b) => {
+					if (b.symbol === token.symbol) {
+						return {
+							...b,
+							amount: b.amount - token.amount,
+						}
+					} else if (b.symbol === fee.symbol) {
+						return {
+							...b,
+							amount: b.amount - fee.amount,
+						}
+					}
+					return b
+				}),
+			}))
+		}
+
+		await storeBalances(this.waku, to, {
+			...balanceToDoc,
+			balances: balanceToDoc.balances.map((b) => {
+				if (b.symbol === token.symbol) {
+					return {
+						...b,
+						amount: b.amount + token.amount,
+					}
+				}
+				return b
+			}),
 		})
-		throw new Error('Method not implemented.')
+
+		await storeDocument(this.waku, 'transactions', '', tx)
+
+		return ''
+	}
+
+	async estimateTransaction(): Promise<Token> {
+		return {
+			name: 'Ether',
+			symbol: 'ETH',
+			amount: 123000000000000000n,
+			decimals: 18,
+		}
+	}
+
+	/**
+	 * THIS IS JUST FOR DEV PURPOSES
+	 */
+	async initializeBalances(wallet: HDNodeWallet): Promise<void> {
+		const { address } = wallet
+
+		if (!address) throw new Error('Address is missing')
+
+		const ethData = {
+			name: 'Ether',
+			symbol: 'ETH',
+			decimals: 18,
+			amount: 50000000000000000000n,
+			image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
+		}
+
+		const daiData = {
+			name: 'Dai',
+			symbol: 'DAI',
+			decimals: 18,
+			amount: 7843900000000000000000n,
+			image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/4943.png',
+		}
+
+		const balances = [ethData, daiData]
+		const balancesState = {
+			balances,
+			loading: false,
+		}
+		balanceStore.set(balancesState)
+
+		if (!this.waku) {
+			this.waku = await connectWaku()
+		}
+
+		storeBalances(this.waku, address, balancesState)
 	}
 }

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -22,7 +22,15 @@ const peerMultiaddr = multiaddr(
 	'/dns4/ws.waku-1.apyos.dev/tcp/443/wss/p2p/16Uiu2HAm8gXHntr3SB5sde11pavjptaoiqyvwoX3GyEZWKMPiuBu',
 )
 
-type ContentTopic = 'private-message' | 'profile' | 'contact' | 'chats' | 'all-users' | 'objects'
+type ContentTopic =
+	| 'private-message'
+	| 'profile'
+	| 'contact'
+	| 'chats'
+	| 'all-users'
+	| 'objects'
+	| 'balances'
+	| 'transactions'
 type QueryResult = AsyncGenerator<Promise<DecodedMessage | undefined>[]>
 
 const topicApp = 'wakuobjects-playground'
@@ -82,6 +90,10 @@ export async function readLatestDocument(
 			const message = await messagePromise
 			if (message) {
 				const decodedPayload = decodeMessagePayload(message)
+				// TODO HACK
+				if (!decodedPayload || decodedPayload === 'undefined') {
+					return
+				}
 
 				return JSON.parse(decodedPayload)
 			} else {

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -11,7 +11,6 @@
 	import { walletStore } from '$lib/stores/wallet'
 	import Button from '$lib/components/button.svelte'
 	import { balanceStore } from '$lib/stores/balances'
-	import type FirebaseAdapter from '$lib/adapters/firebase'
 
 	function changeAdapter(adapterName: AdapterName) {
 		saveToLocalStorage('adapter', adapterName)
@@ -21,8 +20,10 @@
 	function initializeBalances() {
 		const wallet = $walletStore.wallet
 
-		if (!wallet) return
-		;(adapter as unknown as FirebaseAdapter).initializeBalances(wallet)
+		if (!wallet) {
+			return
+		}
+		adapter.initializeBalances(wallet)
 	}
 </script>
 
@@ -40,22 +41,20 @@
 		</Dropdown>
 	</section>
 	<Divider />
-	{#if adapterName === 'firebase'}
-		<section>
-			<Button disabled={!$walletStore.wallet} on:click={initializeBalances}
-				>Initialize token balances</Button
-			>
-			{#each $balanceStore.balances as balance}
-				<Asset
-					name={balance.name}
-					token={balance.symbol}
-					amount={balance.amount}
-					decimals={balance.decimals}
-					image={balance.image}
-				/>
-			{/each}
-		</section>
-	{/if}
+	<section>
+		<Button disabled={!$walletStore.wallet} on:click={initializeBalances}
+			>Initialize token balances</Button
+		>
+		{#each $balanceStore.balances as balance}
+			<Asset
+				name={balance.name}
+				token={balance.symbol}
+				amount={balance.amount}
+				decimals={balance.decimals}
+				image={balance.image}
+			/>
+		{/each}
+	</section>
 </Container>
 
 <style lang="scss">


### PR DESCRIPTION
This adapts the changes from the Firebase adapter to the Waku adapter. The current implementation is still considered a simplification, because it does not use the blockchain for transactions, it only simulates it. Therefore I did not try to achieve completeness, because most of the code will change when the real transactions are implemented.

Known issues:
- There is a fundemantal difference between the Firebase and the Waku adapter: with the Firebase everything is written in the database and there are subscriptions on the database that updates the local stores. In the Waku adapter this is the other way around. Because of this currently the balances are not updated automatically. This is however subject to change when real blockchain transactions are implemented.
