### PR TITLE
refactor: resolve accessibility warnings

### DIFF
--- a/src/lib/components/avatar.svelte
+++ b/src/lib/components/avatar.svelte
@@ -8,8 +8,13 @@
 	export let avatarSize = size / 2
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class={`avatar ${onClick !== undefined ? 'click' : ''}`} on:click={onClick}>
+<div
+	class={`avatar ${onClick !== undefined ? 'click' : ''}`}
+	on:click={onClick}
+	on:keypress={onClick}
+	role="button"
+	tabindex={0}
+>
 	<div class="img" style={`height: ${size}px;`}>
 		{#if picture}
 			<img src={adapters.getPicture(picture)} alt="profile" />

--- a/src/lib/components/button-block.svelte
+++ b/src/lib/components/button-block.svelte
@@ -3,10 +3,12 @@
 	export let borderBottom = false
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
 	class={`block-btn ${borderTop ? 'borderTop' : ''} ${borderBottom ? 'borderBottom' : ''} `}
 	on:click
+	on:keypress
+	role="button"
+	tabindex={0}
 >
 	<slot />
 </div>

--- a/src/lib/components/dropdown-item.svelte
+++ b/src/lib/components/dropdown-item.svelte
@@ -4,10 +4,14 @@
 	export let onClick: () => unknown
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
 <li
 	class={`${$$props.class} ${disabled ? 'disabled' : ''} ${danger ? 'danger' : ''}`}
 	on:click={() => !disabled && onClick()}
+	on:keypress={() => !disabled && onClick()}
+	role="option"
+	tabindex={0}
+	aria-selected={false}
+	aria-disabled={disabled}
 >
 	<slot />
 </li>

--- a/src/lib/components/dropdown.svelte
+++ b/src/lib/components/dropdown.svelte
@@ -10,6 +10,7 @@
 
 	let showDropdown = false
 	let dropdownElement: HTMLElement
+	let dropdownId: string
 
 	const closeDropdown = (ev: MouseEvent) => {
 		const target = ev.target as unknown as Node
@@ -23,6 +24,9 @@
 
 	onMount(() => {
 		if (browser && window) window.addEventListener('click', closeDropdown)
+
+		// Generates unique ID for this dropdown instance (used for ARIA attributes)
+		dropdownId = `dropdown-${Math.random().toString(36).substring(7)}`
 	})
 
 	onDestroy(() => {
@@ -31,16 +35,31 @@
 
 	// Trigger event when dropdown is opened or closed
 	$: showDropdown ? dispatch('open') : dispatch('close')
+
+	function onClick() {
+		if (!disabled) showDropdown = !showDropdown
+	}
 </script>
 
-<div bind:this={dropdownElement} class="dropdown">
-	<!-- svelte-ignore a11y-click-events-have-key-events -->
-	<div on:click={() => !disabled && (showDropdown = !showDropdown)}>
+<div
+	bind:this={dropdownElement}
+	class="dropdown"
+	role="combobox"
+	aria-haspopup="listbox"
+	aria-expanded={showDropdown}
+	aria-controls={dropdownId}
+>
+	<div on:click={onClick} on:keypress={onClick} role="button" tabindex={0}>
 		<slot name="button" disabled />
 	</div>
 
-	<div class={`root`}>
-		<ul class={`${showDropdown ? '' : 'hidden'} ${up ? 'up' : ''} ${left ? 'left' : ''}`}>
+	<div class={`root`} aria-hidden={!showDropdown}>
+		<ul
+			class={`${showDropdown ? '' : 'hidden'} ${up ? 'up' : ''} ${left ? 'left' : ''}`}
+			id={dropdownId}
+			role="listbox"
+			aria-labelledby="dropdown-button"
+		>
 			<slot />
 		</ul>
 	</div>

--- a/src/lib/components/input-field.svelte
+++ b/src/lib/components/input-field.svelte
@@ -5,8 +5,6 @@
 	export let disabled = false
 	export let pad = 0
 	export let label: string | undefined = undefined
-
-	let inputField: HTMLInputElement
 </script>
 
 <div class="input-wrapper">
@@ -22,7 +20,6 @@
 		{autofocus}
 		{placeholder}
 		bind:value
-		bind:this={inputField}
 		on:keydown
 		on:keypress
 		on:keyup

--- a/src/lib/components/input-file.svelte
+++ b/src/lib/components/input-file.svelte
@@ -6,7 +6,6 @@
 
 <label class={`input-file`}>
 	<slot />
-	<!-- svelte-ignore a11y-missing-attribute -->
 	<input type="file" {disabled} bind:files hidden {multiple} />
 </label>
 

--- a/src/lib/components/object-link.svelte
+++ b/src/lib/components/object-link.svelte
@@ -7,8 +7,7 @@
 	export let description: string | undefined = undefined
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class={`object`} on:click>
+<div class={`object`} on:click on:keypress role="button" tabindex={0}>
 	<Container direction="row" gap={12} alignItems="center">
 		<img class="img" src={imgSrc} alt={imgAlt} />
 		<p>

--- a/src/lib/components/select.svelte
+++ b/src/lib/components/select.svelte
@@ -8,8 +8,13 @@
 	export let disabled: boolean | undefined = undefined
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class={`root ${cls} ${disabled ? 'disabled' : ''}`} on:click>
+<div
+	class={`root ${cls} ${disabled ? 'disabled' : ''}`}
+	on:click
+	on:keypress
+	role="menu"
+	tabindex={0}
+>
 	<div class="label">
 		{label}
 	</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -106,37 +106,44 @@
 			</Button>
 		</svelte:fragment>
 	</Header>
-	<ul class="chats">
+	<ul class="chats" aria-label="Chat List">
 		{#each [...$chats.chats] as [id, chat]}
 			{@const userMessages = chat.messages.filter((message) => message.type === 'user')}
 			{@const lastMessage = userMessages[userMessages.length - 1]}
 			{@const myMessage = lastMessage.fromAddress === $walletStore.wallet.address}
 			{@const otherUser = chat.users.find((m) => m.address !== $walletStore.wallet?.address)}
 			{#if lastMessage && lastMessage.type === 'user'}
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<li on:click={() => goto(ROUTES.CHAT(id))}>
-					<Container grow>
-						<div class="chat">
-							<!-- TODO: WHAT HAPPENS TO THE AVATAR IF IT'S A GROUP CHAT? -->
-							{#if chat.users.length === 2}
-								<Avatar size={70} picture={otherUser?.avatar} />
-							{/if}
-							<div class="content">
-								<div class="user-info">
-									<span class="username text-lg text-bold">
-										{otherUser?.name}
-										<Badge dark>
-											{chat.messages.length}
-										</Badge>
-									</span>
+				<li>
+					<div
+						class="chat-button"
+						on:click={() => goto(ROUTES.CHAT(id))}
+						on:keypress={() => goto(ROUTES.CHAT(id))}
+						role="button"
+						tabindex="0"
+					>
+						<Container grow>
+							<div class="chat">
+								<!-- TODO: WHAT HAPPENS TO THE AVATAR IF IT'S A GROUP CHAT? -->
+								{#if chat.users.length === 2}
+									<Avatar size={70} picture={otherUser?.avatar} />
+								{/if}
+								<div class="content">
+									<div class="user-info">
+										<span class="username text-lg text-bold">
+											{otherUser?.name}
+											<Badge dark>
+												{chat.messages.length}
+											</Badge>
+										</span>
+									</div>
+									<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
+										{myMessage ? 'You: ' : ''}
+										{lastMessage.text.substring(0, 50)}
+									</p>
 								</div>
-								<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
-									{myMessage ? 'You: ' : ''}
-									{lastMessage.text.substring(0, 50)}
-								</p>
 							</div>
-						</div>
-					</Container>
+						</Container>
+					</div>
 				</li>
 			{/if}
 		{:else}
@@ -174,8 +181,12 @@
 			display: flex;
 			align-items: center;
 			gap: var(--spacing-12);
-			cursor: pointer;
 			border-bottom: 1px solid var(--gray20);
+
+			.chat-button {
+				width: 100%;
+				cursor: pointer;
+			}
 		}
 	}
 


### PR DESCRIPTION
I know this is super low priority but I was annoyed about the warnings and I always wanted to understand a bit better the accessibility guidelines.

I still kept `<!-- svelte-ignore a11y-autofocus -->` on the `input` and `textarea` because these are up to us to decide.