### PR TITLE
feat: to significant digits token amount formatting

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest'
-
-describe('sum test', () => {
-	it('adds 1 + 2 to equal 3', () => {
-		expect(1 + 2).toBe(3)
-	})
-})

--- a/src/lib/components/asset.svelte
+++ b/src/lib/components/asset.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Container from '$lib/components/container.svelte'
-	import { formatTokenAmount } from '$lib/utils/format'
+	import { toSignificant } from '$lib/utils/format'
 	export let name: string
 	export let token: string
 	export let amount: bigint
@@ -17,7 +17,7 @@
 			</span>
 		</div>
 		<div class="text-lg">
-			{formatTokenAmount(amount, decimals)}
+			{toSignificant(amount, decimals)}
 			{token}
 		</div>
 	</Container>

--- a/src/lib/objects/payggy/chat.svelte
+++ b/src/lib/objects/payggy/chat.svelte
@@ -3,7 +3,7 @@
 	import type { WakuObjectArgs } from '..'
 	import type { SendTransaction } from './schemas'
 	import type { DataMessage } from '$lib/stores/chat'
-	import { formatTokenAmount } from '$lib/utils/format'
+	import { toSignificant } from '$lib/utils/format'
 	import ChatMessage from '$lib/components/chat-message.svelte'
 	import ReadonlyText from '$lib/components/readonly-text.svelte'
 	import ObjectHeader from '$lib/components/object-header.svelte'
@@ -51,10 +51,10 @@
 				<!-- This is an error state -->
 				Failed to parse store or message data. Check console for details.
 			{:else if myMessage}
-				You sent {formatTokenAmount(BigInt(data.token.amount), data.token.decimals)}
+				You sent {toSignificant(BigInt(data.token.amount), data.token.decimals)}
 				{data.token.symbol} to {otherUser.name}
 			{:else}
-				You received {formatTokenAmount(BigInt(data.token.amount), data.token.decimals)}
+				You received {toSignificant(BigInt(data.token.amount), data.token.decimals)}
 				{data.token.symbol} from {otherUser.name}
 			{/if}
 			{#if args.store && message.data && store && data}
@@ -67,7 +67,7 @@
 							<ArrowDownRight />
 						{/if}
 						<div class="grow text-lg">
-							{formatTokenAmount(BigInt(data.token.amount), data.token.decimals)}
+							{toSignificant(BigInt(data.token.amount), data.token.decimals)}
 							{data.token.symbol}
 						</div>
 						<!-- TODO: add action to icon -->

--- a/src/lib/objects/payggy/standalone.svelte
+++ b/src/lib/objects/payggy/standalone.svelte
@@ -15,7 +15,7 @@
 	import DropdownItem from '$lib/components/dropdown-item.svelte'
 	import Close from '$lib/components/icons/close.svelte'
 
-	import { formatAddress, formatTokenAmount } from '$lib/utils/format'
+	import { formatAddress, toSignificant, toBigInt } from '$lib/utils/format'
 	import type { WakuObjectArgs } from '..'
 	import {
 		SendTransactionStandaloneSchema,
@@ -41,14 +41,14 @@
 	let fee: Token | undefined = undefined
 	$: if (!token) token = store.nativeToken
 	$: if (args.estimateTransaction && amount && token) {
-		const tokenToTransfer = { ...token, amount: BigInt(Number(amount) * 10 ** token.decimals) }
+		const tokenToTransfer = { ...token, amount: toBigInt(amount, token.decimals) }
 		args.estimateTransaction(store.toUser.address, tokenToTransfer).then((f) => (fee = f))
 	}
 	$: if (!amount && store.view === 'overview') history.back()
 
 	async function sendTransaction() {
 		if (args.sendTransaction && fee) {
-			const tokenToTransfer = { ...token, amount: BigInt(Number(amount) * 10 ** token.decimals) }
+			const tokenToTransfer = { ...token, amount: toBigInt(amount, token.decimals) }
 
 			const tx = await args.sendTransaction(store.toUser.address, tokenToTransfer, fee)
 			// FIXME: check the amount is actually number and convert to some bigint mechanism which does not lose precision
@@ -106,20 +106,19 @@
 		</ReadonlyText>
 		<ReadonlyText label="Transaction fee (max)">
 			<div class="text-lg">
-				{fee ? `${formatTokenAmount(fee.amount, fee.decimals)} ${fee.symbol}` : 'unknown'}
+				{fee ? `${toSignificant(fee.amount, fee.decimals)} ${fee.symbol}` : 'unknown'}
 			</div>
 			<div class="secondary text-sm">≈ 1.56 EUR now</div>
 		</ReadonlyText>
 		<p
 			class={`balance ${
-				Number(amount) > Number(formatTokenAmount(token.amount, token.decimals)) ? 'text-bold' : ''
+				Number(amount) > Number(toSignificant(token.amount, token.decimals)) ? 'text-bold' : ''
 			}`}
 		>
-			{#if Number(amount) > Number(formatTokenAmount(token.amount, token.decimals))}
+			{#if Number(amount) > Number(toSignificant(token.amount, token.decimals))}
 				<WarningAltFilled />
 			{/if}
-			You have {formatTokenAmount(store.nativeToken.amount, store.nativeToken.decimals)} ETH in your
-			account.
+			You have {toSignificant(store.nativeToken.amount, store.nativeToken.decimals)} ETH in your account.
 		</p>
 	</Container>
 	<Container direction="row" justify="space-between" alignItems="center" padX={24}>
@@ -160,20 +159,20 @@
 		</div>
 		<p
 			class={`balance ${
-				Number(amount) > Number(formatTokenAmount(token.amount, token.decimals)) ? 'text-bold' : ''
+				Number(amount) > Number(toSignificant(token.amount, token.decimals)) ? 'text-bold' : ''
 			}`}
 		>
-			{#if Number(amount) > Number(formatTokenAmount(token.amount, token.decimals))}
+			{#if Number(amount) > Number(toSignificant(token.amount, token.decimals))}
 				<WarningAltFilled />
 			{/if}
-			You have {formatTokenAmount(token.amount, token.decimals)}
+			You have {toSignificant(token.amount, token.decimals)}
 			{token.symbol} in your account.
 		</p>
 	</Container>
 	<Container justify="flex-end">
 		<Button
 			variant="strong"
-			disabled={!amount || Number(amount) > Number(formatTokenAmount(token.amount, token.decimals))}
+			disabled={!amount || Number(amount) > Number(toSignificant(token.amount, token.decimals))}
 			on:click={() => args.onViewChange && args.onViewChange('overview')}
 		>
 			<ArrowRight />

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { toDecimal, toSignificantString, toBigInt } from './format'
+
+describe('toDecimal', () => {
+	const testValues = [
+		{ amount: 1000000000000000000n, decimals: 18, expectedOut: '1.000000000000000000' },
+		{ amount: 1234567890123456789n, decimals: 18, expectedOut: '1.234567890123456789' },
+		{ amount: 123456789012345678900n, decimals: 18, expectedOut: '123.456789012345678900' },
+		{ amount: 100n, decimals: 2, expectedOut: '1.00' },
+		{ amount: 123456789n, decimals: 0, expectedOut: '123456789' },
+		{ amount: 123456789n, decimals: 9, expectedOut: '0.123456789' },
+		{ amount: 123456789n, decimals: 5, expectedOut: '1234.56789' },
+	]
+
+	testValues.forEach(({ amount, decimals, expectedOut }) => {
+		it(`with amount=${amount} and decimals=${decimals} should return ${expectedOut}`, () => {
+			expect(toDecimal(amount, decimals)).toEqual(expectedOut)
+		})
+	})
+})
+
+describe('toSignificantString', () => {
+	const testValues = [
+		{ value: '1.234567890123456789', minDecSigDigits: 0, expectedOut: '1' },
+		{ value: '1.234567890123456789', minDecSigDigits: 4, expectedOut: '1.2345' },
+		{ value: '0.001234567890123456', minDecSigDigits: 4, expectedOut: '0.001234' },
+		{ value: '1', minDecSigDigits: 2, expectedOut: '1.00' },
+		{ value: '1.234', minDecSigDigits: undefined, expectedOut: '1.23' },
+		{ value: '0.00001234', minDecSigDigits: undefined, expectedOut: '0.000012' },
+		{ value: '0.0000001000', minDecSigDigits: 3, expectedOut: '0.0000001' },
+	]
+
+	testValues.forEach(({ value, minDecSigDigits, expectedOut }) => {
+		it(`with value=${value} and minDecSigDigits=${minDecSigDigits} should return ${expectedOut}`, () => {
+			expect(toSignificantString(value, minDecSigDigits)).toEqual(expectedOut)
+		})
+	})
+})
+
+describe('toBigInt', () => {
+	const testValues = [
+		{ value: '1.234567890123456789', decimals: 18, expectedOut: 1234567890123456789n },
+		{ value: '1.234567890123456789', decimals: 6, expectedOut: 1234567n },
+		{ value: '0.00012345', decimals: 3, expectedOut: 0n },
+		{ value: '0.0009999', decimals: 3, expectedOut: 0n },
+		{ value: '0.001', decimals: 3, expectedOut: 1n },
+		{ value: '0', decimals: 3, expectedOut: 0n },
+		{ value: '0.0', decimals: 3, expectedOut: 0n },
+		{ value: '1', decimals: 3, expectedOut: 1000n },
+	]
+
+	testValues.forEach(({ value, decimals, expectedOut }) => {
+		it(`with value=${value} and decimals=${decimals} should return ${expectedOut}`, () => {
+			expect(toBigInt(value, decimals)).toEqual(expectedOut)
+		})
+	})
+})

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -3,6 +3,65 @@ export function formatAddress(address: string, prefix = 4, suffix = 0) {
 	return `${address.substring(0, prefix + 2)}`
 }
 
-export function formatTokenAmount(amount: bigint, decimals: number, precision = 2): string {
-	return (Number(amount / 10n ** BigInt(decimals - precision)) / 10 ** precision).toFixed(precision)
+export function toSignificant(
+	amount: bigint,
+	decimals: number,
+	minDecimalsOrSignificantDigits = 2,
+): string {
+	return toSignificantString(toDecimal(amount, decimals), minDecimalsOrSignificantDigits)
+}
+
+export function toDecimal(amount: bigint, decimals: number): string {
+	const str = amount.toString()
+
+	if (decimals === 0) return str
+
+	const wholePart = str.slice(0, -decimals) || '0'
+	const fractionalPart = str.slice(-decimals).padStart(decimals, '0')
+
+	return wholePart + (fractionalPart ? '.' + fractionalPart : '')
+}
+
+export function toSignificantString(value: string, minDecimalsOrSignificantDigits = 2): string {
+	const split = value.split('.')
+	const wholePart = split[0]
+	let fractionalPart = (split[1] || '').replace(/0+$/, '')
+
+	let firstNonZeroIndex = -1
+	for (let i = 0; i < fractionalPart.length; i++) {
+		if (firstNonZeroIndex === -1 && fractionalPart[i] !== '0') {
+			firstNonZeroIndex = i
+			break
+		}
+	}
+	if (firstNonZeroIndex === -1) firstNonZeroIndex = 0
+
+	fractionalPart = fractionalPart
+		.slice(0, firstNonZeroIndex + minDecimalsOrSignificantDigits)
+		.padEnd(minDecimalsOrSignificantDigits, '0')
+
+	return wholePart + (fractionalPart ? '.' + fractionalPart : '')
+}
+
+function validateDecimal(number: string) {
+	// This regex will match a string that starts with one or more digits (\d+),
+	// followed by an optional part that starts with a dot (\.?) and continues with one or more digits (\d*)
+	const regex = /^\d+(\.\d*)?$/
+
+	if (!regex.test(number)) {
+		throw new Error('Invalid decimal number format')
+	}
+}
+
+export function toBigInt(decimalString: string, decimals: number): bigint | never {
+	validateDecimal(decimalString)
+
+	// Split the string into whole and fractional parts
+	const [wholePart, fractionalPart = ''] = decimalString.split('.')
+
+	// Construct a new string with the correct number of decimals
+	const paddedFractionalPart = fractionalPart.padEnd(decimals, '0').slice(0, decimals)
+
+	// Parse the resulting string to a BigInt
+	return BigInt(wholePart + paddedFractionalPart)
 }


### PR DESCRIPTION
Resolves #169 

This add token manipulation methods which have full bigint precision

Method `toBigInt` - validates and parses string representing token into bigint representation
     ✓ with value=1.234567890123456789 and decimals=18 should return 1234567890123456789
     ✓ with value=1.234567890123456789 and decimals=6 should return 1234567
     ✓ with value=0.00012345 and decimals=3 should return 0
     ✓ with value=0.0009999 and decimals=3 should return 0
     ✓ with value=0.001 and decimals=3 should return 1
     ✓ with value=0 and decimals=3 should return 0
     ✓ with value=0.0 and decimals=3 should return 0
     ✓ with value=1 and decimals=3 should return 1000
     
Method `toSignificant` - formats token representation with amount as bigint and decimals to string which has some minimal fractional significant digits
     ✓ with value=1.234567890123456789 and minDecSigDigits=0 should return 1
     ✓ with value=1.234567890123456789 and minDecSigDigits=4 should return 1.2345
     ✓ with value=0.001234567890123456 and minDecSigDigits=4 should return 0.001234
     ✓ with value=1 and minDecSigDigits=2 should return 1.00
     ✓ with value=1.234 and minDecSigDigits=undefined should return 1.23
     ✓ with value=0.00001234 and minDecSigDigits=undefined should return 0.000012
     ✓ with value=0.0000001000 and minDecSigDigits=3 should return 0.0000001