### PR TITLE
style: fix corners and spacing on chat bubbles

### DIFF
--- a/src/lib/components/chat-message.svelte
+++ b/src/lib/components/chat-message.svelte
@@ -4,11 +4,7 @@
 
 	const isFF = () => {
 		let browserInfo = navigator.userAgent
-		if (browserInfo.includes('Firefox')) {
-			return true
-		} else {
-			return false
-		}
+		return browserInfo.includes('Firefox'))
 	}
 </script>
 

--- a/src/lib/components/chat-message.svelte
+++ b/src/lib/components/chat-message.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
 	export let bubble = false
 	export let myMessage = false
+
+	const isFF = () => {
+		let browserInfo = navigator.userAgent
+		if (browserInfo.includes('Firefox')) {
+			return true
+		} else {
+			return false
+		}
+	}
 </script>
 
-<div class={`message ${myMessage ? 'my-message' : 'their-message'}`}>
+<div class={`message ${myMessage ? 'my-message' : 'their-message'} ${isFF() ? 'ff' : ''}`}>
 	<div class={` ${bubble ? 'bubble message-content message-text text-lg' : ''}`}>
 		<slot />
 	</div>
@@ -40,10 +49,12 @@
 		margin-left: auto;
 		margin-right: 0;
 
-		& + .my-message .message-text {
+		//The + combinator matches the second element only if it immediately follows the first element.
+		& + .my-message:not(.ff) .message-text {
 			border-top-right-radius: 0;
 		}
 
+		//This combination matches the first element only if it immediately precedes the second element.
 		&:has(+ .my-message) {
 			margin-bottom: var(--spacing-6);
 
@@ -57,10 +68,12 @@
 		align-items: flex-start;
 		text-align: left;
 
-		& + .their-message .message-text {
+		//The + combinator matches the second element only if it immediately follows the first element.
+		& + .their-message:not(.ff) .message-text {
 			border-top-left-radius: 0;
 		}
 
+		//This combination matches the first element only if it immediately precedes the second element.
 		&:has(+ .their-message) {
 			margin-bottom: var(--spacing-6);
 			.message-text {

--- a/src/lib/components/chat-message.svelte
+++ b/src/lib/components/chat-message.svelte
@@ -4,7 +4,7 @@
 
 	const isFF = () => {
 		let browserInfo = navigator.userAgent
-		return browserInfo.includes('Firefox'))
+		return browserInfo.includes('Firefox')
 	}
 </script>
 

--- a/src/lib/components/chat-message.svelte
+++ b/src/lib/components/chat-message.svelte
@@ -39,11 +39,34 @@
 		font-style: italic;
 		margin-left: auto;
 		margin-right: 0;
+
+		& + .my-message .message-text {
+			border-top-right-radius: 0;
+		}
+
+		&:has(+ .my-message) {
+			margin-bottom: var(--spacing-6);
+
+			.message-text {
+				border-bottom-right-radius: 0;
+			}
+		}
 	}
 
 	.their-message {
 		align-items: flex-start;
 		text-align: left;
+
+		& + .their-message .message-text {
+			border-top-left-radius: 0;
+		}
+
+		&:has(+ .their-message) {
+			margin-bottom: var(--spacing-6);
+			.message-text {
+				border-bottom-left-radius: 0;
+			}
+		}
 
 		.message-content {
 			text-align: left;


### PR DESCRIPTION
Known issue: This won't work on Firefox. 

CSS doesn't have a "previous" sibling selector, so I had to use the :has() relational pseudo-class to achieve the same result. Unfortunately, :has() is not yet supported on Firefox (see [here](https://caniuse.com/?search=%3Ahas)). 

The alternative solution would be to use javascript to achieve the desired result, however I believe that since this is a visual enhancement, the performance cost might not be worth it.