### PR TITLE
feat: transaction status

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"eslint": "^8.44.0",
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"ethers": "^6.6.2",
+		"ethers": "^6.6.4",
 		"firebase": "^9.23.0",
 		"hardhat": "^2.16.1",
 		"ipfs-http-client": "^60.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ devDependencies:
     specifier: ^4.0.0
     version: 4.0.0(eslint@8.44.0)(svelte@4.0.3)
   ethers:
-    specifier: ^6.6.2
-    version: 6.6.2
+    specifier: ^6.6.4
+    version: 6.6.4
   firebase:
     specifier: ^9.23.0
     version: 9.23.0
@@ -4140,8 +4140,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /ethers@6.6.2:
-    resolution: {integrity: sha512-vyWfVAj2g7xeZIivOqlbpt7PbS2MzvJkKgsncgn4A/1xZr8Q3BznBmEBRQyPXKCgHmX4PzRQLpnYG7jl/yutMg==}
+  /ethers@6.6.4:
+    resolution: {integrity: sha512-r3myN2hEnydmu23iiIj5kjWnCh5JNzlqrE/z+Kw5UqH173F+JOWzU6qkFB4HVC50epgxzKSL2Hq1oNXA877vwQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.9.2

--- a/src/lib/adapters/balance.ts
+++ b/src/lib/adapters/balance.ts
@@ -1,7 +1,7 @@
 import { balanceStore, type Token } from '$lib/stores/balances'
 import { defaultBlockchainNetwork, getBalance } from '$lib/adapters/transaction'
 
-export async function initializeBalances(address: string): Promise<void> {
+export async function fetchBalances(address: string): Promise<void> {
 	balanceStore.update((state) => ({
 		...state,
 		loading: true,

--- a/src/lib/adapters/balance.ts
+++ b/src/lib/adapters/balance.ts
@@ -1,0 +1,49 @@
+import { balanceStore, type Token } from '$lib/stores/balances'
+import { defaultBlockchainNetwork, getBalance } from '$lib/adapters/transaction'
+
+export async function initializeBalances(address: string): Promise<void> {
+	balanceStore.update((state) => ({
+		...state,
+		loading: true,
+	}))
+
+	const nativeTokenAmount = await getBalance(address)
+
+	const ethData = {
+		...defaultBlockchainNetwork.nativeToken,
+		amount: nativeTokenAmount,
+	}
+
+	const daiData = {
+		name: 'Dai',
+		symbol: 'DAI',
+		decimals: 18,
+		amount: 7843900000000000000000n,
+		image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/4943.png',
+	}
+
+	const balances = [ethData, daiData]
+	const balancesState = {
+		balances,
+		loading: false,
+	}
+	balanceStore.set(balancesState)
+}
+
+export async function checkBalance(address: string, token: Token): Promise<void> {
+	const nativeTokenAmount = await getBalance(address)
+
+	balanceStore.update((balanceState) => ({
+		...balanceState,
+		balances: balanceState.balances.map((value) => {
+			if (value.symbol !== token.symbol) {
+				return value
+			} else {
+				return {
+					...value,
+					amount: nativeTokenAmount,
+				}
+			}
+		}),
+	}))
+}

--- a/src/lib/adapters/firebase/index.ts
+++ b/src/lib/adapters/firebase/index.ts
@@ -34,7 +34,7 @@ import { type Unsubscriber, get } from 'svelte/store'
 import { sleep } from '../utils'
 import { sendTransaction } from '$lib/adapters/transaction'
 import { makeWakuObjectAdapter } from '$lib/objects/adapter'
-import { initializeBalances } from '$lib/adapters/balance'
+import { fetchBalances } from '$lib/adapters/balance'
 
 export default class FirebaseAdapter implements Adapter {
 	protected userSubscriptions: Array<() => unknown> = []
@@ -182,7 +182,7 @@ export default class FirebaseAdapter implements Adapter {
 		})
 		this.userSubscriptions.push(subscribeUsers)
 
-		initializeBalances(address)
+		fetchBalances(address)
 	}
 
 	onLogOut() {

--- a/src/lib/adapters/firebase/schemas.ts
+++ b/src/lib/adapters/firebase/schemas.ts
@@ -1,16 +1,6 @@
 import { AddressSchema } from '$lib/utils/schemas'
 import { z } from 'zod'
 
-export const TokenDbSchema = z.object({
-	name: z.string(),
-	symbol: z.string(),
-	amount: z.preprocess((v) => BigInt(v as string), z.bigint().nonnegative()),
-	decimals: z.number().int().positive(),
-	image: z.string().optional(),
-	address: AddressSchema.optional(),
-})
-export type TokenDb = z.infer<typeof TokenDbSchema>
-
 export const UserDbSchema = z.object({
 	address: AddressSchema,
 	name: z.string().optional(),

--- a/src/lib/adapters/firebase/schemas.ts
+++ b/src/lib/adapters/firebase/schemas.ts
@@ -6,7 +6,7 @@ export const TokenDbSchema = z.object({
 	symbol: z.string(),
 	amount: z.preprocess((v) => BigInt(v as string), z.bigint().nonnegative()),
 	decimals: z.number().int().positive(),
-	image: z.string(),
+	image: z.string().optional(),
 	address: AddressSchema.optional(),
 })
 export type TokenDb = z.infer<typeof TokenDbSchema>

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -31,10 +31,6 @@ export interface Adapter {
 	): Promise<void>
 	sendTransaction(wallet: BaseWallet, to: string, token: Token, fee: Token): Promise<string>
 	estimateTransaction(wallet: BaseWallet, to: string, token: Token): Promise<Token>
-
-	// THIS IS JUST FOR DEV PURPOSES
-	initializeBalances(address: string): Promise<void>
-	checkBalance(address: string, token: Token): Promise<void>
 }
 
 const DEFAULT_ADAPTER = 'firebase'

--- a/src/lib/adapters/transaction.ts
+++ b/src/lib/adapters/transaction.ts
@@ -31,7 +31,8 @@ const testBlockchain: BlockchainNetwork = {
 const chiadoBlockchain: BlockchainNetwork = {
 	name: 'Chiado testnet',
 	// provider: 'https://rpc.chiadochain.net/',
-	provider: 'https://rpc.chiado.gnosis.gateway.fm',
+	// provider: 'https://rpc.chiado.gnosis.gateway.fm',
+	provider: 'https://rpc.chiado.apyos.dev/',
 	nativeToken: {
 		name: 'Chiado xDai',
 		symbol: 'xDai',
@@ -55,7 +56,7 @@ const sepoliaBlockchain: BlockchainNetwork = {
 	},
 }
 
-export const defaultBlockchainNetwork = sepoliaBlockchain
+export const defaultBlockchainNetwork = chiadoBlockchain
 
 export function getProvider(): Provider {
 	const providerUrl = defaultBlockchainNetwork.provider

--- a/src/lib/adapters/transaction.ts
+++ b/src/lib/adapters/transaction.ts
@@ -1,3 +1,4 @@
+import type { Token } from '$lib/objects/schemas'
 import {
 	JsonRpcProvider,
 	type BaseWallet,
@@ -5,6 +6,7 @@ import {
 	TransactionReceipt,
 	type TransactionResponseParams,
 	type Provider,
+	TransactionResponse,
 } from 'ethers'
 
 type SendTransactionResponse = TransactionResponseParams & {
@@ -12,22 +14,46 @@ type SendTransactionResponse = TransactionResponseParams & {
 }
 
 interface BlockchainNetwork {
-	nativeToken: string
+	nativeToken: Token
 	provider: string
 }
 
 const testBlockchain: BlockchainNetwork = {
-	nativeToken: 'ETH',
+	nativeToken: {
+		name: 'Test Ether',
+		symbol: 'ETH',
+		decimals: 18,
+		image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
+		amount: BigInt(0),
+	},
 	provider: 'http://127.0.0.1:8545',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const chiadoBlockchain: BlockchainNetwork = {
-	nativeToken: 'XDAI',
+	nativeToken: {
+		name: 'Chiado xDai',
+		symbol: 'xDai',
+		decimals: 18,
+		image: 'https://docs.gnosischain.com/img/tokens/chiado-xdai.png',
+		amount: BigInt(0),
+	},
 	provider: 'https://rpc.chiadochain.net/',
 }
 
-export const defaultBlockchainNetwork = testBlockchain
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const sepoliaBlockchain: BlockchainNetwork = {
+	nativeToken: {
+		name: 'Sepolia ETH',
+		symbol: 'SEP',
+		decimals: 18,
+		image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
+		amount: BigInt(0),
+	},
+	provider: 'https://rpc.sepolia.dev',
+}
+
+export const defaultBlockchainNetwork = chiadoBlockchain
 
 function getProvider(): Provider {
 	const providerUrl = defaultBlockchainNetwork.provider
@@ -41,7 +67,7 @@ export async function sendTransaction(
 	amount: bigint,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	fee: bigint,
-): Promise<SendTransactionResponse> {
+): Promise<TransactionResponse> {
 	const provider = getProvider()
 	const txWallet = wallet.connect(provider)
 
@@ -51,16 +77,33 @@ export async function sendTransaction(
 	}
 
 	const tx = await txWallet.sendTransaction(txRequest)
-	const receipt = await tx.wait()
 
-	return {
-		...tx,
-		receipt,
-	}
+	return tx
+}
+
+export async function waitForTransaction(
+	txHash: string,
+	confirm?: number | undefined,
+): Promise<TransactionReceipt | null> {
+	const provider = getProvider()
+	const receipt = provider.waitForTransaction(txHash, confirm)
+	return receipt
 }
 
 export async function getBalance(address: string): Promise<bigint> {
 	const provider = getProvider()
 	const balance = provider.getBalance(address)
 	return balance
+}
+
+export async function getTransactionResponse(txHash: string): Promise<TransactionResponse | null> {
+	const provider = getProvider()
+	const tx = await provider.getTransaction(txHash)
+	return tx
+}
+
+export async function getTransactionReceipt(txHash: string): Promise<TransactionReceipt | null> {
+	const provider = getProvider()
+	const receipt = await provider.getTransactionReceipt(txHash)
+	return receipt
 }

--- a/src/lib/adapters/transaction.ts
+++ b/src/lib/adapters/transaction.ts
@@ -4,21 +4,20 @@ import {
 	type BaseWallet,
 	type TransactionRequest,
 	TransactionReceipt,
-	type TransactionResponseParams,
 	type Provider,
 	TransactionResponse,
 } from 'ethers'
 
-type SendTransactionResponse = TransactionResponseParams & {
-	receipt: TransactionReceipt | null
-}
-
 interface BlockchainNetwork {
-	nativeToken: Token
+	name: string
 	provider: string
+	nativeToken: Token
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const testBlockchain: BlockchainNetwork = {
+	name: 'Local testnet',
+	provider: 'http://127.0.0.1:8545',
 	nativeToken: {
 		name: 'Test Ether',
 		symbol: 'ETH',
@@ -26,11 +25,13 @@ const testBlockchain: BlockchainNetwork = {
 		image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
 		amount: BigInt(0),
 	},
-	provider: 'http://127.0.0.1:8545',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const chiadoBlockchain: BlockchainNetwork = {
+	name: 'Chiado testnet',
+	// provider: 'https://rpc.chiadochain.net/',
+	provider: 'https://rpc.chiado.gnosis.gateway.fm',
 	nativeToken: {
 		name: 'Chiado xDai',
 		symbol: 'xDai',
@@ -38,11 +39,13 @@ const chiadoBlockchain: BlockchainNetwork = {
 		image: 'https://docs.gnosischain.com/img/tokens/chiado-xdai.png',
 		amount: BigInt(0),
 	},
-	provider: 'https://rpc.chiadochain.net/',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const sepoliaBlockchain: BlockchainNetwork = {
+	name: 'Sepolia testnet',
+	// provider: 'https://rpc.sepolia.org/',
+	provider: 'https://rpc2.sepolia.org/ ',
 	nativeToken: {
 		name: 'Sepolia ETH',
 		symbol: 'SEP',
@@ -50,12 +53,11 @@ const sepoliaBlockchain: BlockchainNetwork = {
 		image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
 		amount: BigInt(0),
 	},
-	provider: 'https://rpc.sepolia.dev',
 }
 
-export const defaultBlockchainNetwork = chiadoBlockchain
+export const defaultBlockchainNetwork = sepoliaBlockchain
 
-function getProvider(): Provider {
+export function getProvider(): Provider {
 	const providerUrl = defaultBlockchainNetwork.provider
 	const provider = new JsonRpcProvider(providerUrl)
 	return provider

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -20,7 +20,7 @@ import { get } from 'svelte/store'
 import { objectStore, type ObjectState, objectKey } from '$lib/stores/objects'
 import { lookup } from '$lib/objects/lookup'
 import { balanceStore, type Token } from '$lib/stores/balances'
-import { getBalance } from '../transaction'
+import { defaultBlockchainNetwork, getBalance, sendTransaction } from '$lib/adapters/transaction'
 import type { WakuObjectAdapter } from '$lib/objects'
 import { makeWakuObjectAdapter } from '$lib/objects/adapter'
 
@@ -51,13 +51,13 @@ function createChat(chatId: string, user: User, address: string): string {
 	return chatId
 }
 
-function addMessageToChat(
+async function addMessageToChat(
 	address: string,
 	adapter: WakuObjectAdapter,
 	chatId: string,
 	message: Message,
 ) {
-	executeOnMessage(address, adapter, message)
+	await executeOnMessage(address, adapter, message)
 
 	chats.update((state) => {
 		if (!state.chats.has(chatId)) {
@@ -78,7 +78,7 @@ function addMessageToChat(
 	})
 }
 
-function executeOnMessage(address: string, adapter: WakuObjectAdapter, chatMessage: Message) {
+async function executeOnMessage(address: string, adapter: WakuObjectAdapter, chatMessage: Message) {
 	if (chatMessage.type === 'data') {
 		const descriptor = lookup(chatMessage.objectId)
 		const key = objectKey(chatMessage.objectId, chatMessage.instanceId)
@@ -86,14 +86,18 @@ function executeOnMessage(address: string, adapter: WakuObjectAdapter, chatMessa
 
 		if (descriptor && descriptor.onMessage && wakuObjectStore.lastUpdated < chatMessage.timestamp) {
 			const objects = wakuObjectStore.objects
-			const newStore = descriptor.onMessage(address, adapter, objects.get(key), chatMessage)
-			const newObjects = new Map(objects)
-			newObjects.set(key, newStore)
-			objectStore.update((state) => ({
-				...state,
-				objects: newObjects,
-				lastUpdated: chatMessage.timestamp,
-			}))
+			const store = objects.get(key)
+			const updateStore = (updater: (store: unknown) => unknown) => {
+				const newStore = updater(store)
+				const newObjects = new Map(objects)
+				newObjects.set(key, newStore)
+				objectStore.update((state) => ({
+					...state,
+					objects: newObjects,
+					lastUpdated: chatMessage.timestamp,
+				}))
+			}
+			await descriptor.onMessage(address, adapter, store, updateStore, chatMessage)
 		}
 	}
 }
@@ -363,61 +367,8 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	async sendTransaction(wallet: Wallet, to: string, token: Token, fee: Token): Promise<string> {
-		const { address } = wallet
-
-		if (!address) throw new Error('Address is missing')
-
-		if (!this.waku) {
-			throw 'no waku'
-		}
-
-		const tx = {
-			from: address,
-			to,
-			token: {
-				amount: token.amount.toString(),
-				name: token.name,
-				symbol: token.symbol,
-				decimals: token.decimals,
-			},
-			timestamp: Date.now(),
-			fee: {
-				amount: fee.amount.toString(),
-				symbol: fee.symbol,
-				name: fee.name,
-				decimals: fee.decimals,
-			},
-		}
-
-		// Update balances
-		const balanceFromDoc = get(balanceStore)
-		const balanceFrom = balanceFromDoc.balances.find((balance) => balance.symbol === token.symbol)
-		const feeFrom = balanceFromDoc.balances.find((balance) => balance.symbol === fee.symbol)
-		if (!balanceFrom || !feeFrom) throw new Error('Balance not found')
-
-		if (balanceFrom.amount - token.amount >= 0 && feeFrom.amount - fee.amount >= 0) {
-			balanceStore.update((prevState) => ({
-				...prevState,
-				balances: prevState.balances.map((b) => {
-					if (b.symbol === token.symbol) {
-						return {
-							...b,
-							amount: b.amount - token.amount,
-						}
-					} else if (b.symbol === fee.symbol) {
-						return {
-							...b,
-							amount: b.amount - fee.amount,
-						}
-					}
-					return b
-				}),
-			}))
-		}
-
-		await storeDocument(this.waku, 'transactions', '', tx)
-
-		return ''
+		const tx = await sendTransaction(wallet, to, token.amount, fee.amount)
+		return tx.hash
 	}
 
 	async estimateTransaction(): Promise<Token> {
@@ -436,11 +387,8 @@ export default class WakuAdapter implements Adapter {
 		const nativeTokenAmount = await getBalance(address)
 
 		const ethData = {
-			name: 'Ether',
-			symbol: 'ETH',
-			decimals: 18,
+			...defaultBlockchainNetwork.nativeToken,
 			amount: nativeTokenAmount,
-			image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
 		}
 
 		const daiData = {

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -23,7 +23,7 @@ import type { Token } from '$lib/stores/balances'
 import { defaultBlockchainNetwork, sendTransaction } from '$lib/adapters/transaction'
 import type { WakuObjectAdapter } from '$lib/objects'
 import { makeWakuObjectAdapter } from '$lib/objects/adapter'
-import { initializeBalances } from '$lib/adapters/balance'
+import { fetchBalances } from '$lib/adapters/balance'
 
 function createChat(chatId: string, user: User, address: string): string {
 	chats.update((state) => {
@@ -236,7 +236,7 @@ export default class WakuAdapter implements Adapter {
 		})
 		this.subscriptions.push(subscribeObjectStore)
 
-		initializeBalances(address)
+		fetchBalances(address)
 	}
 
 	async onLogOut() {

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -219,7 +219,7 @@ export default class WakuAdapter implements Adapter {
 					}
 				}
 
-				addMessageToChat(address, wakuObjectAdapter, chatMessage.fromAddress, chatMessage)
+				await addMessageToChat(address, wakuObjectAdapter, chatMessage.fromAddress, chatMessage)
 			},
 		)
 		this.subscriptions.push(subscribeChats)
@@ -300,7 +300,7 @@ export default class WakuAdapter implements Adapter {
 
 		const wakuObjectAdapter = makeWakuObjectAdapter(this, wallet)
 
-		addMessageToChat(fromAddress, wakuObjectAdapter, chatId, message)
+		await addMessageToChat(fromAddress, wakuObjectAdapter, chatId, message)
 		await sendMessage(this.waku, chatId, message)
 	}
 
@@ -327,7 +327,7 @@ export default class WakuAdapter implements Adapter {
 
 		const wakuObjectAdapter = makeWakuObjectAdapter(this, wallet)
 
-		addMessageToChat(fromAddress, wakuObjectAdapter, chatId, message)
+		await addMessageToChat(fromAddress, wakuObjectAdapter, chatId, message)
 		await sendMessage(this.waku, chatId, message)
 	}
 
@@ -373,10 +373,8 @@ export default class WakuAdapter implements Adapter {
 
 	async estimateTransaction(): Promise<Token> {
 		return {
-			name: 'Ether',
-			symbol: 'ETH',
-			amount: 123000000000000000n,
-			decimals: 18,
+			...defaultBlockchainNetwork.nativeToken,
+			amount: 1000059237n,
 		}
 	}
 
@@ -384,6 +382,11 @@ export default class WakuAdapter implements Adapter {
 	 * THIS IS JUST FOR DEV PURPOSES
 	 */
 	async initializeBalances(address: string): Promise<void> {
+		balanceStore.update((state) => ({
+			...state,
+			loading: true,
+		}))
+
 		const nativeTokenAmount = await getBalance(address)
 
 		const ethData = {

--- a/src/lib/components/asset.svelte
+++ b/src/lib/components/asset.svelte
@@ -11,7 +11,7 @@
 <div class="asset root">
 	<Container justify="space-between" align="center" alignItems="center" direction="row">
 		<div class="token">
-			<img src={image} alt={`${name} logo`} />
+			<img src={image} alt={`${name} logo`} width="64" height="64" />
 			<span class="text-lg text-bold">
 				{name}
 			</span>

--- a/src/lib/objects/adapter.ts
+++ b/src/lib/objects/adapter.ts
@@ -1,7 +1,17 @@
 import type { Adapter } from '$lib/adapters'
-import type { BaseWallet } from 'ethers'
+import type { BaseWallet, TransactionReceipt } from 'ethers'
 import type { WakuObjectAdapter } from '.'
 import type { Token } from '$lib/stores/balances'
+import {
+	defaultBlockchainNetwork,
+	getTransactionReceipt,
+	getTransactionResponse,
+	waitForTransaction,
+} from '$lib/adapters/transaction'
+import type { Transaction, TransactionState } from './schemas'
+import { throwError } from '$lib/utils/error'
+
+const NUM_CONFIRMATIONS = 5
 
 export function makeWakuObjectAdapter(adapter: Adapter, wallet: BaseWallet): WakuObjectAdapter {
 	const { address } = wallet
@@ -18,7 +28,68 @@ export function makeWakuObjectAdapter(adapter: Adapter, wallet: BaseWallet): Wak
 		await adapter.checkBalance(address, token)
 	}
 
+	async function getTransaction(txHash: string): Promise<Transaction> {
+		const tx = await getTransactionResponse(txHash)
+		if (!tx) {
+			throwError('transaction not found')
+		}
+		const from = tx.from
+		const to = tx.to || ''
+		const token = {
+			...defaultBlockchainNetwork.nativeToken,
+			amount: tx.value.toString(),
+		}
+		return {
+			from,
+			to,
+			fee: {
+				symbol: '',
+				amount: '0', // has to be non-zero
+				decimals: 18,
+			},
+			token,
+		}
+	}
+
+	async function transactionReceiptToState(
+		receipt: TransactionReceipt | null,
+	): Promise<TransactionState> {
+		if (!receipt) {
+			return 'unknown'
+		}
+		const confirmations = await receipt.confirmations()
+		if (confirmations < NUM_CONFIRMATIONS) {
+			return 'pending'
+		}
+
+		console.debug({ receipt, confirmations })
+
+		if (receipt.status !== null) {
+			if (receipt.status === 0) {
+				return 'reverted'
+			}
+			if (receipt.status === 1) {
+				return 'success'
+			}
+		}
+		return 'unknown'
+	}
+
+	async function getTransactionState(txHash: string): Promise<TransactionState> {
+		const receipt = await getTransactionReceipt(txHash)
+		console.debug('getTransactionState', { receipt })
+		return transactionReceiptToState(receipt)
+	}
+
+	async function _waitForTransaction(txHash: string): Promise<TransactionState> {
+		const receipt = await waitForTransaction(txHash, NUM_CONFIRMATIONS)
+		return transactionReceiptToState(receipt)
+	}
+
 	return {
+		getTransaction,
+		getTransactionState,
+		waitForTransaction: _waitForTransaction,
 		checkBalance,
 		sendTransaction,
 		estimateTransaction,

--- a/src/lib/objects/adapter.ts
+++ b/src/lib/objects/adapter.ts
@@ -9,6 +9,7 @@ import {
 	waitForTransaction,
 } from '$lib/adapters/transaction'
 import type { Transaction, TransactionState } from './schemas'
+import { checkBalance } from '$lib/adapters/balance'
 
 const NUM_CONFIRMATIONS = 2
 
@@ -23,8 +24,8 @@ export function makeWakuObjectAdapter(adapter: Adapter, wallet: BaseWallet): Wak
 		return adapter.estimateTransaction(wallet, to, token)
 	}
 
-	async function checkBalance(token: Token): Promise<void> {
-		await adapter.checkBalance(address, token)
+	async function _checkBalance(token: Token): Promise<void> {
+		await checkBalance(address, token)
 	}
 
 	async function getTransaction(txHash: string): Promise<Transaction | undefined> {
@@ -89,7 +90,7 @@ export function makeWakuObjectAdapter(adapter: Adapter, wallet: BaseWallet): Wak
 		getTransaction,
 		getTransactionState,
 		waitForTransaction: _waitForTransaction,
-		checkBalance,
+		checkBalance: _checkBalance,
 		sendTransaction,
 		estimateTransaction,
 	}

--- a/src/lib/objects/chat.svelte
+++ b/src/lib/objects/chat.svelte
@@ -36,6 +36,10 @@
 
 	$: tokens = $balanceStore.balances
 
+	function updateStore(updater: (state: unknown) => unknown) {
+		adapter.updateStore(address, message.objectId, message.instanceId, updater)
+	}
+
 	let args: WakuObjectArgs
 	$: if (userProfile) {
 		const wakuObjectAdapter = makeWakuObjectAdapter(adapter, wallet)
@@ -45,11 +49,9 @@
 			users,
 			tokens,
 			store,
-			updateStore: (updater) => {
-				adapter.updateStore(address, message.objectId, message.instanceId, updater)
-			},
 			send: (data: unknown) =>
 				adapter.sendData(wallet, chatId, message.objectId, message.instanceId, data),
+			updateStore,
 			...wakuObjectAdapter,
 		}
 	}

--- a/src/lib/objects/hello-world/index.ts
+++ b/src/lib/objects/hello-world/index.ts
@@ -16,7 +16,7 @@ export const helloWorldDescriptor: WakuObjectDescriptor = {
 
 	wakuObject: HelloWorld,
 
-	onMessage: (address, adapter, store, message) => {
-		return message.data
+	onMessage: async (address, adapter, store, updateStore, message) => {
+		updateStore(() => message.data)
 	},
 }

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -4,7 +4,7 @@ import type { ComponentType } from 'svelte'
 import type { Transaction, User, TransactionState } from './schemas'
 
 export interface WakuObjectAdapter {
-	getTransaction(txHash: string): Promise<Transaction>
+	getTransaction(txHash: string): Promise<Transaction | undefined>
 	getTransactionState(txHash: string): Promise<TransactionState>
 	waitForTransaction(txHash: string): Promise<TransactionState>
 	checkBalance(token: Token): Promise<void>

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -1,9 +1,12 @@
 import type { Token } from '$lib/stores/balances'
 import type { DataMessage } from '$lib/stores/chat'
 import type { ComponentType } from 'svelte'
-import type { User } from './schemas'
+import type { Transaction, User, TransactionState } from './schemas'
 
 export interface WakuObjectAdapter {
+	getTransaction(txHash: string): Promise<Transaction>
+	getTransactionState(txHash: string): Promise<TransactionState>
+	waitForTransaction(txHash: string): Promise<TransactionState>
 	checkBalance(token: Token): Promise<void>
 	sendTransaction: (to: string, token: Token, fee: Token) => Promise<string>
 	estimateTransaction: (to: string, token: Token) => Promise<Token>
@@ -38,7 +41,8 @@ interface WakuObjectDescriptor {
 		address: string,
 		adapter: WakuObjectAdapter,
 		store: WakuStoreType,
+		updateStore: (updater: (state: WakuStoreType) => WakuStoreType) => void,
 		message: DataMessage<DataMessageType>,
-	) => WakuStoreType
+	) => Promise<void>
 	// TODO onTransaction: (store: unknown, transaction: Transaction) => unknown
 }

--- a/src/lib/objects/payggy/chat.svelte
+++ b/src/lib/objects/payggy/chat.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import {
-		type MessageDataSend,
-		MessageDataSendSchema,
+		type SendTransactionDataMessage,
 		type SendTransactionStore,
 		SendTransactionStoreSchema,
 	} from './schemas'
@@ -18,8 +17,8 @@
 	import Container from '$lib/components/container.svelte'
 	import logo from './logo.svg'
 
-	export let message: DataMessage<MessageDataSend>
-	export let args: WakuObjectArgs<SendTransactionStore, MessageDataSend>
+	export let message: DataMessage<SendTransactionDataMessage>
+	export let args: WakuObjectArgs<SendTransactionStore, SendTransactionDataMessage>
 
 	let data: SendTransactionStore
 	$: {
@@ -36,7 +35,6 @@
 	$: myMessage = message.fromAddress === args.profile.address
 	// FIXME: will not work for group chats
 	$: otherUser = args.users.find((u) => u.address !== args.profile.address)
-	$: console.debug({ data })
 </script>
 
 <ChatMessage {myMessage} bubble>

--- a/src/lib/objects/payggy/index.ts
+++ b/src/lib/objects/payggy/index.ts
@@ -1,6 +1,6 @@
 import type { WakuObjectDescriptor } from '..'
 import ChatComponent from './chat.svelte'
-import { MessageDataSendSchema } from './schemas'
+import { SendTransactionDataMessageSchema } from './schemas'
 import StandaloneComponent from './standalone.svelte'
 import logo from './logo.svg'
 
@@ -17,38 +17,42 @@ export const payggyDescriptor: WakuObjectDescriptor = {
 	standalone: StandaloneComponent,
 
 	onMessage: async (address, adapter, store, updateStore, message) => {
-		if (message?.data) {
-			const res = MessageDataSendSchema.safeParse(message.data)
-			if (res.success) {
-				const state = await adapter.getTransactionState(res.data.hash)
-				if (state === 'pending' || state === 'success') {
-					console.debug('onMessage', { state })
-					const tx = await adapter.getTransaction(res.data.hash)
-
-					console.debug('onMessage', { state, tx })
-
-					updateStore(() => ({
-						type: state,
-						transaction: tx,
-						hash: res.data.hash,
-					}))
-
-					const token = {
-						...tx.token,
-						name: tx.token.symbol,
-						amount: BigInt(0), // the amount is not really necessary for checkBalance
-					}
-
-					await adapter.checkBalance(token)
-				} else if (state === 'reverted') {
-					const tx = await adapter.getTransaction(res.data.hash)
-					updateStore(() => ({
-						type: 'error',
-						transaction: tx,
-						error: 'Transaction has failed!',
-					}))
-				}
-			}
+		if (!message?.data) {
+			return
 		}
+
+		const res = SendTransactionDataMessageSchema.safeParse(message.data)
+		if (!res.success) {
+			return
+		}
+
+		const tx = await adapter.getTransaction(res.data.hash)
+		if (!tx) {
+			return
+		}
+
+		const state = await adapter.getTransactionState(res.data.hash)
+		if (state === 'reverted') {
+			updateStore(() => ({
+				type: 'error',
+				transaction: tx,
+				error: 'Transaction has failed!',
+			}))
+			return
+		}
+
+		updateStore(() => ({
+			type: state === 'success' ? 'success' : 'pending',
+			transaction: tx,
+			hash: res.data.hash,
+		}))
+
+		const token = {
+			...tx.token,
+			name: tx.token.symbol,
+			amount: BigInt(0), // the amount is not really necessary for checkBalance
+		}
+
+		await adapter.checkBalance(token)
 	},
 }

--- a/src/lib/objects/payggy/index.ts
+++ b/src/lib/objects/payggy/index.ts
@@ -16,19 +16,39 @@ export const payggyDescriptor: WakuObjectDescriptor = {
 
 	standalone: StandaloneComponent,
 
-	onMessage: (address, adapter, store, message) => {
+	onMessage: async (address, adapter, store, updateStore, message) => {
 		if (message?.data) {
 			const res = MessageDataSendSchema.safeParse(message.data)
 			if (res.success) {
-				const token = {
-					...res.data.token,
-					name: res.data.token.symbol,
-					amount: BigInt(0), // the amount is not really necessary for checkBalance
+				const state = await adapter.getTransactionState(res.data.hash)
+				if (state === 'pending' || state === 'success') {
+					console.debug('onMessage', { state })
+					const tx = await adapter.getTransaction(res.data.hash)
+
+					console.debug('onMessage', { state, tx })
+
+					updateStore(() => ({
+						type: state,
+						transaction: tx,
+						hash: res.data.hash,
+					}))
+
+					const token = {
+						...tx.token,
+						name: tx.token.symbol,
+						amount: BigInt(0), // the amount is not really necessary for checkBalance
+					}
+
+					await adapter.checkBalance(token)
+				} else if (state === 'reverted') {
+					const tx = await adapter.getTransaction(res.data.hash)
+					updateStore(() => ({
+						type: 'error',
+						transaction: tx,
+						error: 'Transaction has failed!',
+					}))
 				}
-				adapter.checkBalance(token)
 			}
 		}
-
-		return message.data
 	},
 }

--- a/src/lib/objects/payggy/schemas.ts
+++ b/src/lib/objects/payggy/schemas.ts
@@ -24,7 +24,7 @@ export const SendTransactionStoreSchema = z.union([
 ])
 export type SendTransactionStore = z.infer<typeof SendTransactionStoreSchema>
 
-export const MessageDataSendSchema = z.object({
+export const SendTransactionDataMessageSchema = z.object({
 	hash: TransactionHashSchema,
 })
-export type MessageDataSend = z.infer<typeof MessageDataSendSchema>
+export type SendTransactionDataMessage = z.infer<typeof SendTransactionDataMessageSchema>

--- a/src/lib/objects/payggy/schemas.ts
+++ b/src/lib/objects/payggy/schemas.ts
@@ -1,47 +1,6 @@
 import z from 'zod'
-import { TokenSchema, UserSchema } from '../schemas'
-import { AddressSchema, TransactionHashSchema } from '$lib/utils/schemas'
-
-export const SendTransactionSchema = z.object({
-	token: z.object({
-		amount: z.string(),
-		symbol: z.string(),
-		decimals: z.number().int().positive(),
-	}),
-	to: AddressSchema,
-	from: AddressSchema,
-	fee: z.object({
-		amount: z.string(),
-		symbol: z.string(),
-		decimals: z.number().int().positive(),
-	}),
-})
-export type SendTransaction = z.infer<typeof SendTransactionSchema>
-
-export const TransactionSchema = z.object({
-	token: z.object({
-		amount: z.string(),
-		symbol: z.string(),
-		decimals: z.number().int().positive(),
-	}),
-	to: AddressSchema,
-	from: AddressSchema,
-	fee: z.object({
-		amount: z.string(),
-		symbol: z.string(),
-		decimals: z.number().int().positive(),
-	}),
-})
-export type Transaction = z.infer<typeof SendTransactionSchema>
-
-export const SendTransactionStandaloneSchema = z.object({
-	view: z.string().optional(),
-	tokens: z.array(TokenSchema),
-	nativeToken: TokenSchema,
-	fromUser: UserSchema,
-	toUser: UserSchema,
-})
-export type SendTransactionStandalone = z.infer<typeof SendTransactionStandaloneSchema>
+import { TransactionSchema } from '../schemas'
+import { TransactionHashSchema } from '$lib/utils/schemas'
 
 export const SendTransactionStoreSchema = z.union([
 	z.object({
@@ -53,26 +12,19 @@ export const SendTransactionStoreSchema = z.union([
 		hash: TransactionHashSchema,
 	}),
 	z.object({
-		type: z.literal('complete'),
+		type: z.literal('success'),
 		transaction: TransactionSchema,
 		hash: TransactionHashSchema,
+	}),
+	z.object({
+		type: z.literal('error'),
+		transaction: TransactionSchema,
+		error: z.string(),
 	}),
 ])
 export type SendTransactionStore = z.infer<typeof SendTransactionStoreSchema>
 
 export const MessageDataSendSchema = z.object({
-	token: z.object({
-		amount: z.string(),
-		symbol: z.string(),
-		decimals: z.number().int().positive(),
-	}),
-	to: AddressSchema,
-	from: AddressSchema,
-	fee: z.object({
-		amount: z.string(),
-		symbol: z.string(),
-		decimals: z.number().int().positive(),
-	}),
-	tx: z.string(),
+	hash: TransactionHashSchema,
 })
 export type MessageDataSend = z.infer<typeof MessageDataSendSchema>

--- a/src/lib/objects/payggy/standalone.svelte
+++ b/src/lib/objects/payggy/standalone.svelte
@@ -68,14 +68,15 @@
 				hash: transactionHash,
 			})
 
-			history.go(-3)
-
+			// FIXME this may not get invoked if navigated away from this page
 			setTimeout(async () => {
 				await args.waitForTransaction(transactionHash)
 				await args.send({
 					hash: transactionHash,
 				})
 			}, 0)
+
+			history.go(-3)
 		}
 	}
 </script>

--- a/src/lib/objects/schemas.ts
+++ b/src/lib/objects/schemas.ts
@@ -17,3 +17,27 @@ export const UserSchema = z.object({
 	avatar: z.string().optional(),
 })
 export type User = z.infer<typeof UserSchema>
+
+export const TransactionSchema = z.object({
+	token: z.object({
+		amount: z.string(),
+		symbol: z.string(),
+		decimals: z.number().int().positive(),
+	}),
+	to: AddressSchema,
+	from: AddressSchema,
+	fee: z.object({
+		amount: z.string(),
+		symbol: z.string(),
+		decimals: z.number().int().positive(),
+	}),
+})
+export type Transaction = z.infer<typeof TransactionSchema>
+
+export const TransactionStateSchema = z.union([
+	z.literal('unknown'),
+	z.literal('pending'),
+	z.literal('reverted'),
+	z.literal('success'),
+])
+export type TransactionState = z.infer<typeof TransactionStateSchema>

--- a/src/lib/objects/ui.svelte
+++ b/src/lib/objects/ui.svelte
@@ -48,7 +48,7 @@
 		return adapter.sendData($walletStore.wallet, chatId, objectId, instanceId, data)
 	}
 
-	function updateStore(updater: (state: unknown) => unknown): void {
+	function updateStore(updater: (state: unknown) => unknown) {
 		adapter.updateStore(address, objectId, instanceId, updater)
 	}
 
@@ -62,8 +62,8 @@
 			users,
 			tokens,
 			store,
-			updateStore,
 			send,
+			updateStore,
 			onViewChange,
 			...wakuObjectAdapter,
 		}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,6 +1,6 @@
 export function formatAddress(address: string, prefix = 4, suffix = 0) {
-	if (suffix) return `${address.substring(0, prefix + 2)}...${address.substring(-suffix, suffix)}`
-	return `${address.substring(0, prefix + 2)}`
+	if (suffix) return `${address.slice(0, prefix + 2)}...${address.slice(-suffix)}`
+	return `${address.slice(0, prefix + 2)}`
 }
 
 export function toSignificant(

--- a/src/routes/chat/[id]/object/new/+page.svelte
+++ b/src/routes/chat/[id]/object/new/+page.svelte
@@ -29,6 +29,7 @@
 					createObject(object.objectId, {
 						/* TODO empty */
 					})
+					goto(ROUTES.CHAT($page.params.id))
 			  },
 	}))
 	let loading = false

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -2,7 +2,7 @@
 	import Header from '$lib/components/header.svelte'
 	import Container from '$lib/components/container.svelte'
 	import Divider from '$lib/components/divider.svelte'
-	import adapter, { adapterName, adapters, type AdapterName } from '$lib/adapters'
+	import { adapterName, adapters, type AdapterName } from '$lib/adapters'
 	import Dropdown from '$lib/components/dropdown.svelte'
 	import DropdownItem from '$lib/components/dropdown-item.svelte'
 	import Select from '$lib/components/select.svelte'
@@ -12,19 +12,20 @@
 	import Button from '$lib/components/button.svelte'
 	import { balanceStore } from '$lib/stores/balances'
 	import { defaultBlockchainNetwork } from '$lib/adapters/transaction'
+	import { initializeBalances } from '$lib/adapters/balance'
 
 	function changeAdapter(adapterName: AdapterName) {
 		saveToLocalStorage('adapter', adapterName)
 		location.reload()
 	}
 
-	function initializeBalances() {
+	function initializeTokenBalances() {
 		const wallet = $walletStore.wallet
 
 		if (!wallet) {
 			return
 		}
-		adapter.initializeBalances(wallet.address)
+		initializeBalances(wallet.address)
 	}
 </script>
 
@@ -45,7 +46,7 @@
 	</section>
 	<Divider />
 	<section class="assets">
-		<Button disabled={!$walletStore.wallet} on:click={initializeBalances}
+		<Button disabled={!$walletStore.wallet} on:click={initializeTokenBalances}
 			>Initialize token balances</Button
 		>
 		{#if $balanceStore.loading}

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -12,7 +12,7 @@
 	import Button from '$lib/components/button.svelte'
 	import { balanceStore } from '$lib/stores/balances'
 	import { defaultBlockchainNetwork } from '$lib/adapters/transaction'
-	import { initializeBalances } from '$lib/adapters/balance'
+	import { fetchBalances } from '$lib/adapters/balance'
 
 	function changeAdapter(adapterName: AdapterName) {
 		saveToLocalStorage('adapter', adapterName)
@@ -25,7 +25,7 @@
 		if (!wallet) {
 			return
 		}
-		initializeBalances(wallet.address)
+		fetchBalances(wallet.address)
 	}
 </script>
 

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -48,6 +48,11 @@
 		<Button disabled={!$walletStore.wallet} on:click={initializeBalances}
 			>Initialize token balances</Button
 		>
+		{#if $balanceStore.loading}
+			<Container align="center">
+				<h2>Loading...</h2>
+			</Container>
+		{/if}
 		{#each $balanceStore.balances as balance}
 			<Asset
 				name={balance.name}

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -11,6 +11,7 @@
 	import { walletStore } from '$lib/stores/wallet'
 	import Button from '$lib/components/button.svelte'
 	import { balanceStore } from '$lib/stores/balances'
+	import { defaultBlockchainNetwork } from '$lib/adapters/transaction'
 
 	function changeAdapter(adapterName: AdapterName) {
 		saveToLocalStorage('adapter', adapterName)
@@ -39,9 +40,11 @@
 				>
 			{/each}
 		</Dropdown>
+		<div class="label">Network</div>
+		<div class="value">{defaultBlockchainNetwork.name}</div>
 	</section>
 	<Divider />
-	<section>
+	<section class="assets">
 		<Button disabled={!$walletStore.wallet} on:click={initializeBalances}
 			>Initialize token balances</Button
 		>
@@ -64,5 +67,21 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+	}
+
+	.assets {
+		align-items: stretch;
+	}
+
+	.label {
+		font-family: var(--font-body);
+		font-weight: 600;
+		font-size: var(--font-size-sm);
+		color: var(--gray50);
+		margin-bottom: var(--spacing-4);
+	}
+
+	.value {
+		font-family: var(--font-serif);
 	}
 </style>

--- a/src/routes/identity/account/+page.svelte
+++ b/src/routes/identity/account/+page.svelte
@@ -19,7 +19,7 @@
 	import { walletStore } from '$lib/stores/wallet'
 	import { balanceStore } from '$lib/stores/balances'
 	import { onMount } from 'svelte'
-	import { initializeBalances } from '$lib/adapters/balance'
+	import { fetchBalances } from '$lib/adapters/balance'
 
 	let copied = false
 	function copyAddressToClipboard() {
@@ -34,7 +34,7 @@
 		const address = $walletStore.wallet?.address
 		if (address === undefined) return
 
-		initializeBalances(address)
+		fetchBalances(address)
 	})
 </script>
 

--- a/src/routes/identity/account/+page.svelte
+++ b/src/routes/identity/account/+page.svelte
@@ -19,7 +19,7 @@
 	import { walletStore } from '$lib/stores/wallet'
 	import { balanceStore } from '$lib/stores/balances'
 	import { onMount } from 'svelte'
-	import adapter from '$lib/adapters'
+	import { initializeBalances } from '$lib/adapters/balance'
 
 	let copied = false
 	function copyAddressToClipboard() {
@@ -34,7 +34,7 @@
 		const address = $walletStore.wallet?.address
 		if (address === undefined) return
 
-		adapter.initializeBalances(address)
+		initializeBalances(address)
 	})
 </script>
 


### PR DESCRIPTION
With this PR the Payggy object is able to set the status of the transactions on the backend correctly and update it with messages. It only sends the transaction hash in the messages and the peer in the chat reads the transaction from the blockchain based on that.

What is done:
- [x] moved balance out of adapter
- [x] made the Waku and Firebase adapter iterators async to enforce in-order evaluation
    - this was done in order to avoid possible race conditions 
- [x] made the `onMessage` callback async, no longer returns the updated store
    - instead there is a new `updateStore` function passed as argument
- [x] added Sepolia and Chiado testnet configs
  - [x] made Chiado the default 
- [x] made some minor visual fixes in the assets and the dev page
- [x] added transaction states and the Payggy app correctly displays them (except the error, design is missing for that)

Known issues:
- [ ] Payggy still relies on the messages to arrive for updating the transaction state. If the messages does not arrive then the transaction state won't change. It would be good to add some kind of mechanism to keep track of the active transactions locally once they arrived so that the app does not have to rely on messages.
- [ ] I haven't fixed the Token issue (#177) in this PR, but it was very annoying. I suggest removing the `amount` from the `Token` type, and creating an `Amount` type which could have a `token` and a `value` property.
- [ ] Chiado RPC endpoints are currently not working. It seems that Nethermind has an issue with `ethers@v6`. `ethers@v5` would work. Workaround was to set up an alternative endpoint running a different execution client. (https://github.com/NethermindEth/nethermind/issues/5921 and https://github.com/ethers-io/ethers.js/issues/3835)
- [ ] Missing error handling all over the place, especially in the design for the Payggy chat widget.
  - One example: https://github.com/logos-innovation-lab/waku-objects-playground/issues/182
- [ ] Currently there are adapter-like functionalities all over the code (there are Firebase & Waku, balance, transaction and the object adapter). It would be good to consolidate these at some point.
- [ ] There are several `onMessage` arguments now. It would be better to just have two arguments, one `DataMessage` and one `WakuObjectArgs`. I would also rename the latter to `WakuObjectContext`.
- [ ] During testing it happened to me that the two chat apps were on different blockchain network, but they were connected on the same messaging network. Obviously the transactions did not work. Maybe we could include the chain ID in the messages to avoid similar situations.
