### PR TITLE
fix: transaction status update

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -87,8 +87,8 @@ async function executeOnMessage(address: string, adapter: WakuObjectAdapter, cha
 
 		if (descriptor && descriptor.onMessage && wakuObjectStore.lastUpdated < chatMessage.timestamp) {
 			const objects = wakuObjectStore.objects
-			const store = objects.get(key)
-			const updateStore = (updater: (store: unknown) => unknown) => {
+			const updateStore = (updater: (_store: unknown) => unknown) => {
+				const store = objects.get(key)
 				const newStore = updater(store)
 				const newObjects = new Map(objects)
 				newObjects.set(key, newStore)
@@ -98,6 +98,7 @@ async function executeOnMessage(address: string, adapter: WakuObjectAdapter, cha
 					lastUpdated: chatMessage.timestamp,
 				}))
 			}
+			const store = objects.get(key)
 			await descriptor.onMessage(address, adapter, store, updateStore, chatMessage)
 		}
 	}

--- a/src/lib/objects/payggy/standalone.svelte
+++ b/src/lib/objects/payggy/standalone.svelte
@@ -41,6 +41,7 @@
 		}
 	}
 
+	let transactionSent = false
 	let token: Token
 	let amount = ''
 	let fee: Token | undefined = undefined
@@ -61,21 +62,15 @@
 
 	async function sendTransaction() {
 		if (fee) {
+			transactionSent = true
+
 			// FIXME error handling
 			const tokenToTransfer = { ...token, amount: toBigInt(amount, token.decimals) }
 			const transactionHash = await args.sendTransaction(toUser.address, tokenToTransfer, fee)
 
-			args.send({
+			await args.send({
 				hash: transactionHash,
 			})
-
-			// FIXME this may not get invoked if navigated away from this page
-			setTimeout(async () => {
-				await args.waitForTransaction(transactionHash)
-				await args.send({
-					hash: transactionHash,
-				})
-			}, 0)
 
 			history.go(-3)
 		}
@@ -134,7 +129,12 @@
 		<div class="secondary text-normal">
 			{toUser.name ?? formatAddress(toUser.address, 4, 4)}
 		</div>
-		<Button variant="strong" align="right" disabled={!amount} on:click={sendTransaction}>
+		<Button
+			variant="strong"
+			align="right"
+			disabled={!amount || transactionSent}
+			on:click={sendTransaction}
+		>
 			<ArrowUp /> Send now
 		</Button>
 	</Container>


### PR DESCRIPTION
This is a fix for avoiding two widgets in the chat when sending a transaction. It works by waiting for the transaction state change when the message arrives and updating the object's store when that happens.

An edge case where this would not work is when the app is reloaded when the transaction is in pending state. If that happens the transaction will forever stay in pending state. A solution to fix this would be some kind of internal queue for pending transactions.

Fixes #187