### PR TITLE
feat: cli with fund, balance and txinfo commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write . && eslint . --fix",
 		"knip": "knip",
-		"start:blockchain": "hardhat node"
+		"start:blockchain": "hardhat node",
+		"cli": "npx ts-node --esm --experimental-specifier-resolution=node ./src/cli/cli.ts"
 	},
 	"devDependencies": {
 		"@bonosoft/sveltekit-qrcode": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"format": "prettier --plugin-search-dir . --write . && eslint . --fix",
 		"knip": "knip",
 		"start:blockchain": "hardhat node",
-		"cli": "npx ts-node --esm --experimental-specifier-resolution=node ./src/cli/cli.ts"
+		"cli": "ts-node --esm --experimental-specifier-resolution=node ./src/cli/cli.ts"
 	},
 	"devDependencies": {
 		"@bonosoft/sveltekit-qrcode": "^0.0.3",
@@ -42,6 +42,7 @@
 		"svelte": "^4.0.3",
 		"svelte-check": "^3.4.4",
 		"svelte-preprocess": "^5.0.4",
+		"ts-node": "^10.9.1",
 		"typescript": "^5.1.6",
 		"vite": "^4.3.9",
 		"vitest": "^0.32.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ devDependencies:
     version: 6.6.4
   hardhat:
     specifier: ^2.16.1
-    version: 2.16.1(typescript@5.1.6)
+    version: 2.16.1(ts-node@10.9.1)(typescript@5.1.6)
   html5-qrcode:
     specifier: ^2.3.8
     version: 2.3.8
@@ -79,6 +79,9 @@ devDependencies:
   svelte-preprocess:
     specifier: ^5.0.4
     version: 5.0.4(sass@1.63.6)(svelte@4.0.3)(typescript@5.1.6)
+  ts-node:
+    specifier: ^10.9.1
+    version: 10.9.1(typescript@5.1.6)
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -251,6 +254,13 @@ packages:
       '@chainsafe/as-sha256': 0.3.1
       '@chainsafe/persistent-merkle-tree': 0.4.2
       case: 1.6.3
+    dev: true
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
   /@ericcornelissen/bash-parser@0.5.2:
@@ -926,6 +936,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@leichtgewicht/base64-codec@1.0.0:
@@ -2193,6 +2210,22 @@ packages:
     resolution: {integrity: sha512-vqd7ZUDSrXFVT1n8b2kc3LnklncDQFPvR58yUS1kEP23/nHPAO9l1lMjUfnPrXYYk4Hj54rrLKMW5ipwk7k09A==}
     dev: true
 
+  /@tsconfig/node10@1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
   /@types/bn.js@4.11.6:
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
     dependencies:
@@ -2730,6 +2763,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
@@ -3161,6 +3198,10 @@ packages:
       sha.js: 2.4.11
     dev: true
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -3284,6 +3325,11 @@ packages:
   /diff-sequences@29.4.3:
     resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /diff@5.0.0:
@@ -3991,7 +4037,7 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /hardhat@2.16.1(typescript@5.1.6):
+  /hardhat@2.16.1(ts-node@10.9.1)(typescript@5.1.6):
     resolution: {integrity: sha512-QpBjGXFhhSYoYBGEHyoau/A63crZOP+i3GbNxzLGkL6IklzT+piN14+wGnINNCg5BLSKisQI/RAySPzaWRcx/g==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -4049,6 +4095,7 @@ packages:
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
+      ts-node: 10.9.1(typescript@5.1.6)
       tsort: 0.0.1
       typescript: 5.1.6
       undici: 5.22.1
@@ -4987,6 +5034,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
   /map-obj@2.0.0:
@@ -6339,6 +6390,36 @@ packages:
       utf8-byte-length: 1.0.4
     dev: true
 
+  /ts-node@10.9.1(typescript@5.1.6):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      acorn: 8.9.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
@@ -6498,6 +6579,10 @@ packages:
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
+    dev: true
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
   /varint@6.0.0:
@@ -6820,6 +6905,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /yocto-queue@0.1.0:

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,0 +1,58 @@
+// run with npx ts-node --esm --experimental-specifier-resolution=node ./src/cli/cli.ts
+
+import { Wallet, formatUnits, parseEther } from 'ethers'
+import {
+	defaultBlockchainNetwork,
+	getBalance,
+	getProvider,
+	getTransactionReceipt,
+	getTransactionResponse,
+	sendTransaction,
+} from '../lib/adapters/transaction'
+
+async function main() {
+	const command = process.argv[2]
+	const restArgs = process.argv.slice(3)
+
+	const commands: Record<string, (...args: string[]) => Promise<void>> = {
+		fund,
+		balance,
+		txinfo,
+	}
+
+	const fn = commands[command]
+	if (!fn) {
+		throw `unknown command: ${command}`
+	}
+
+	await fn(...restArgs)
+}
+
+async function fund(address: string, amount = '1', fee = '0.1') {
+	console.log(`Funding address: ${address}`)
+	// hardhat builtin wallet private key
+	const wallet = new Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80')
+
+	const tx = await sendTransaction(wallet, address, parseEther(amount), parseEther(fee))
+
+	console.debug('tx done', { tx })
+}
+
+async function balance(address: string) {
+	const decimals = defaultBlockchainNetwork.nativeToken.decimals
+	const symbol = defaultBlockchainNetwork.nativeToken.symbol
+	const bal = await getBalance(address)
+	console.log(`Network: ${defaultBlockchainNetwork.name}`)
+	console.log(`Chain ID: ${(await getProvider().getNetwork()).chainId}`)
+	console.log(`RPC provider: ${defaultBlockchainNetwork.provider}`)
+	console.log(`Balance: ${formatUnits(bal.toString(), decimals)} ${symbol}`)
+}
+
+async function txinfo(hash: string) {
+	const tx = await getTransactionResponse(hash)
+	const receipt = await getTransactionReceipt(hash)
+
+	console.log({ tx, receipt })
+}
+
+main().catch(console.error)

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -35,7 +35,7 @@ async function fund(address: string, amount = '1', fee = '0.1') {
 
 	const tx = await sendTransaction(wallet, address, parseEther(amount), parseEther(fee))
 
-	console.debug('tx done', { tx })
+	console.log('tx done', { tx })
 }
 
 async function balance(address: string) {


### PR DESCRIPTION
For the testing of the group chat I will need some tooling to be able to create scenarios automatically. I already had a CLI tool for funding a node and checking balances, it makes sense to add more commands there.

Usage:

`pnpm cli fund <address> [amount=1] [fee=0.1]`
`pnpm cli balance <address>`
`pnpm cli txinfo <hash>`