### PR TITLE
feat: erc20 transactions in paygy

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -28,12 +28,12 @@ async function main() {
 	await fn(...restArgs)
 }
 
-async function fund(address: string, amount = '1', fee = '0.1') {
+async function fund(address: string, amount = '1') {
 	console.log(`Funding address: ${address}`)
 	// hardhat builtin wallet private key
 	const wallet = new Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80')
 
-	const tx = await sendTransaction(wallet, address, parseEther(amount), parseEther(fee))
+	const tx = await sendTransaction(wallet, address, parseEther(amount))
 
 	console.log('tx done', { tx })
 }

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -27,7 +27,7 @@ export interface Adapter {
 		instanceId: string,
 		updater: (state: unknown) => unknown,
 	): Promise<void>
-	sendTransaction(wallet: BaseWallet, to: string, token: Token, fee: Token): Promise<string>
+	sendTransaction(wallet: BaseWallet, to: string, token: Token): Promise<string>
 	estimateTransaction(wallet: BaseWallet, to: string, token: Token): Promise<Token>
 }
 

--- a/src/lib/adapters/transaction.ts
+++ b/src/lib/adapters/transaction.ts
@@ -6,7 +6,9 @@ import {
 	TransactionReceipt,
 	type Provider,
 	TransactionResponse,
+	Contract,
 } from 'ethers'
+import abi from '$lib/abis/erc20.json'
 
 interface BlockchainNetwork {
 	name: string
@@ -79,18 +81,23 @@ export async function sendTransaction(
 	wallet: BaseWallet,
 	to: string,
 	amount: bigint,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	fee: bigint,
+	tokenAddress?: string,
 ): Promise<TransactionResponse> {
 	const provider = getProvider()
 	const txWallet = wallet.connect(provider)
 
-	const txRequest: TransactionRequest = {
-		to,
-		value: amount,
-	}
+	let tx: TransactionResponse
+	if (tokenAddress) {
+		const contract = new Contract(tokenAddress, abi, txWallet)
+		tx = await contract.transfer(to, amount)
+	} else {
+		const txRequest: TransactionRequest = {
+			to,
+			value: amount,
+		}
 
-	const tx = await txWallet.sendTransaction(txRequest)
+		tx = await txWallet.sendTransaction(txRequest)
+	}
 
 	return tx
 }

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -11,18 +11,17 @@ import {
 	storeDocument,
 	subscribe,
 } from './waku'
-import { Contract, type BaseWallet, type Wallet, TransactionResponse } from 'ethers'
+import type { BaseWallet, Wallet } from 'ethers'
 import { ipfs, IPFS_GATEWAY } from '$lib/adapters/ipfs'
 import { get } from 'svelte/store'
 import { objectStore, type ObjectState, objectKey } from '$lib/stores/objects'
 import { lookup } from '$lib/objects/lookup'
 import type { Token } from '$lib/stores/balances'
-import { defaultBlockchainNetwork, getProvider, sendTransaction } from '$lib/adapters/transaction'
+import { defaultBlockchainNetwork, sendTransaction } from '$lib/adapters/transaction'
 import type { WakuObjectAdapter } from '$lib/objects'
 import { makeWakuObjectAdapter } from '$lib/objects/adapter'
 import { fetchBalances } from '$lib/adapters/balance'
 import type { User } from '$lib/types'
-import abi from '$lib/abis/erc20.json'
 
 function createChat(chatId: string, user: User, address: string): string {
 	chats.update((state) => {
@@ -381,16 +380,8 @@ export default class WakuAdapter implements Adapter {
 		await storeObjectStore(this.waku, address, updatedObjectStore)
 	}
 
-	async sendTransaction(wallet: Wallet, to: string, token: Token, fee: Token): Promise<string> {
-		let tx: TransactionResponse
-		if (token.address) {
-			const provider = getProvider()
-			const txWallet = wallet.connect(provider)
-			const contract = new Contract(token.address, abi, txWallet)
-			tx = await contract.transfer(to, token.amount)
-		} else {
-			tx = await sendTransaction(wallet, to, token.amount, fee.amount)
-		}
+	async sendTransaction(wallet: Wallet, to: string, token: Token): Promise<string> {
+		const tx = await sendTransaction(wallet, to, token.amount, token.address)
 		return tx.hash
 	}
 

--- a/src/lib/objects/adapter.ts
+++ b/src/lib/objects/adapter.ts
@@ -17,8 +17,8 @@ const NUM_CONFIRMATIONS = 2
 export function makeWakuObjectAdapter(adapter: Adapter, wallet: BaseWallet): WakuObjectAdapter {
 	const { address } = wallet
 
-	function sendTransaction(to: string, token: Token, fee: Token) {
-		return adapter.sendTransaction(wallet, to, token, fee)
+	function sendTransaction(to: string, token: Token) {
+		return adapter.sendTransaction(wallet, to, token)
 	}
 
 	function estimateTransaction(to: string, token: Token) {

--- a/src/lib/objects/adapter.ts
+++ b/src/lib/objects/adapter.ts
@@ -1,5 +1,5 @@
 import type { Adapter } from '$lib/adapters'
-import type { BaseWallet, TransactionReceipt } from 'ethers'
+import { Contract, type BaseWallet, type TransactionReceipt } from 'ethers'
 import type { WakuObjectAdapter } from '.'
 import type { Token } from '$lib/stores/balances'
 import {
@@ -10,6 +10,7 @@ import {
 } from '$lib/adapters/transaction'
 import type { Transaction, TransactionState } from './schemas'
 import { checkBalance } from '$lib/adapters/balance'
+import abi from '$lib/abis/erc20.json'
 
 const NUM_CONFIRMATIONS = 2
 
@@ -34,20 +35,43 @@ export function makeWakuObjectAdapter(adapter: Adapter, wallet: BaseWallet): Wak
 			return undefined
 		}
 		const from = tx.from
-		const to = tx.to || ''
-		const token = {
-			...defaultBlockchainNetwork.nativeToken,
-			amount: tx.value.toString(),
+		const nonNativeToken = defaultBlockchainNetwork.tokens?.find((t) => t.address === tx.to)
+
+		let token: Token
+		let to: string
+
+		if (nonNativeToken && tx.to) {
+			const contract = new Contract(tx.to, abi)
+			const parsedTransaction = contract.interface.parseTransaction({ data: tx.data })
+			if (!parsedTransaction) throw new Error('Could not parse transaction')
+
+			to = parsedTransaction.args[0]
+			const amount = parsedTransaction.args[1]
+
+			token = {
+				...nonNativeToken,
+				amount: amount,
+			}
+		} else {
+			token = {
+				...defaultBlockchainNetwork.nativeToken,
+				amount: tx.value,
+			}
+			to = tx.to ?? ''
 		}
+		let feeAmount = 0n
+		if (tx.maxFeePerGas && tx.maxPriorityFeePerGas)
+			feeAmount = tx.gasLimit * tx.maxFeePerGas + tx.gasLimit * tx.maxPriorityFeePerGas
+		else if (tx.gasPrice) feeAmount = tx.gasLimit * tx.gasPrice
+
 		return {
 			from,
 			to,
 			fee: {
-				symbol: '',
-				amount: '0', // has to be non-zero
-				decimals: 18,
+				...defaultBlockchainNetwork.nativeToken,
+				amount: feeAmount.toString(),
 			},
-			token,
+			token: { ...token, amount: token.amount.toString() },
 		}
 	}
 

--- a/src/lib/objects/schemas.ts
+++ b/src/lib/objects/schemas.ts
@@ -34,10 +34,5 @@ export const TransactionSchema = z.object({
 })
 export type Transaction = z.infer<typeof TransactionSchema>
 
-export const TransactionStateSchema = z.union([
-	z.literal('unknown'),
-	z.literal('pending'),
-	z.literal('reverted'),
-	z.literal('success'),
-])
+export const TransactionStateSchema = z.enum(['unknown', 'pending', 'reverted', 'success'])
 export type TransactionState = z.infer<typeof TransactionStateSchema>

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -37,13 +37,10 @@
 
 	onMount(() => {
 		if (browser && div) {
-			// It can not be done in onMount because the div is not yet rendered
-			setTimeout(() => {
-				div.scrollTo({
-					top: div.scrollHeight,
-					behavior: 'auto',
-				})
-			}, 0)
+			div.scrollTo({
+				top: div.scrollHeight,
+				behavior: 'auto',
+			})
 		}
 	})
 


### PR DESCRIPTION
Things to do (likely in separate PR):
- [ ] ~~use bigint for amounts where possible instead of string~~ (can not serialize as JSON when sending over Waku right now, but I'm sure we can use some serialization method)
- [ ] extract contract creation into utility function
- [ ] retrieve used fee from the final transaction receipt (needs to refactor the `getTransactionState` method to return more things)
- [ ] estimate fee before the transaction is sent