### PR TITLE
feat: show name and avatar on invite screen

### DIFF
--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -2,11 +2,13 @@ import type { DraftChat } from '$lib/stores/chat'
 import type { Token } from '$lib/stores/balances'
 import WakuAdapter from '$lib/adapters/waku'
 import type { BaseWallet } from 'ethers'
+import type { User } from '$lib/objects/schemas'
 
 export interface Adapter {
 	onLogIn: (wallet: BaseWallet) => Promise<void>
 	onLogOut: () => void
 	saveUserProfile(address: string, name?: string, avatar?: string): Promise<void>
+	getUserProfile(address: string): Promise<User | undefined>
 
 	startChat(address: string, chat: DraftChat): Promise<string>
 	startGroupChat(wallet: BaseWallet, chat: DraftChat): Promise<string>

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -415,9 +415,16 @@ export default class WakuAdapter implements Adapter {
 		}
 	}
 
+	async getUserProfile(address: string): Promise<User | undefined> {
+		if (!this.waku) {
+			this.waku = await connectWaku()
+		}
+		return readUserFromProfile(this.waku, address)
+	}
+
 	async startChat(address: string, chat: DraftChat): Promise<string> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 		if (chat.users.length !== 2) {
 			throw 'invalid chat'
@@ -442,7 +449,7 @@ export default class WakuAdapter implements Adapter {
 
 	async startGroupChat(wallet: BaseWallet, chat: DraftChat): Promise<string> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 		if (chat.users.length === 0) {
 			throw 'invalid chat'
@@ -474,7 +481,7 @@ export default class WakuAdapter implements Adapter {
 
 	async addMemberToGroupChat(chatId: string, users: string[]): Promise<void> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 
 		const waku = this.waku
@@ -510,7 +517,7 @@ export default class WakuAdapter implements Adapter {
 
 	async sendChatMessage(wallet: BaseWallet, chatId: string, text: string): Promise<void> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 
 		const fromAddress = wallet.address
@@ -535,7 +542,7 @@ export default class WakuAdapter implements Adapter {
 		data: unknown,
 	): Promise<void> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 
 		const fromAddress = wallet.address
@@ -556,7 +563,7 @@ export default class WakuAdapter implements Adapter {
 
 	async sendInvite(wallet: BaseWallet, chatId: string, users: string[]): Promise<void> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 
 		if (!isGroupChatId(chatId)) {
@@ -584,7 +591,7 @@ export default class WakuAdapter implements Adapter {
 		updater: (state: unknown) => unknown,
 	): Promise<void> {
 		if (!this.waku) {
-			throw 'no waku'
+			this.waku = await connectWaku()
 		}
 
 		const key = objectKey(objectId, instanceId)


### PR DESCRIPTION
Resolves #186 but likely needs some styling love.

Please note, that the design in sketch is quite different, because it has a specific version of connect identity screen. I would suggest that we do not implement it at least now (and I see it as quite low priority). See attached screenshots.

How the invite screen looks as of this PR:
![Screenshot 2023-08-14 at 19 37 40](https://github.com/logos-innovation-lab/waku-objects-playground/assets/7974813/a59e95f8-28eb-4af5-9a76-358d697e5151)

Designs in sketch:

![Screenshot 2023-08-14 at 19 34 56](https://github.com/logos-innovation-lab/waku-objects-playground/assets/7974813/39fd81b6-831d-4048-9933-2c35a2447f09)
![Screenshot 2023-08-14 at 19 35 03](https://github.com/logos-innovation-lab/waku-objects-playground/assets/7974813/983ebdd5-3216-40fc-89cc-7870b17e7ff1)
![Screenshot 2023-08-14 at 19 35 08](https://github.com/logos-innovation-lab/waku-objects-playground/assets/7974813/36fb1db1-e2dd-4b61-91f7-1378cfc42f3b)

