### PR TITLE
style: replace group settings icon

### DIFF
--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -25,7 +25,6 @@
 	import type { HDNodeWallet } from 'ethers/lib.commonjs'
 	import Layout from '$lib/components/layout.svelte'
 	import Events from '$lib/components/icons/events.svelte'
-	import Edit from '$lib/components/icons/edit.svelte'
 	import { textToHTML } from '$lib/utils/text'
 
 	let div: HTMLElement
@@ -88,7 +87,7 @@
 					slot="right"
 					on:click={() => goto(ROUTES.GROUP_EDIT($page.params.id))}
 				>
-					<Edit />
+					<Events />
 				</Button>
 			</Header>
 			<div class="chat-messages" bind:this={div}>


### PR DESCRIPTION
There is currently only one action implemented for the group chat - group settings. This PR replaces the previously used Edit icon with the group icon shown on the design

![Screenshot 2023-08-14 at 2 38 45 PM](https://github.com/logos-innovation-lab/waku-objects-playground/assets/16855117/83a42304-29a7-41b0-ab26-d7538bd526a1)
