### PR TITLE
refactor: waku storage

### DIFF
--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -14,6 +14,7 @@ export interface Adapter {
 	startGroupChat(wallet: BaseWallet, chat: DraftChat): Promise<string>
 
 	addMemberToGroupChat(chatId: string, users: string[]): Promise<void>
+	removeFromGroupChat(chatId: string, address: string): Promise<void>
 	saveGroupChatProfile(chatId: string): Promise<void>
 
 	sendChatMessage(wallet: BaseWallet, chatId: string, text: string): Promise<void>

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -10,7 +10,7 @@ export interface Adapter {
 	saveUserProfile(address: string, name?: string, avatar?: string): Promise<void>
 	getUserProfile(address: string): Promise<User | undefined>
 
-	startChat(address: string, chat: DraftChat): Promise<string>
+	startChat(address: string, peerAddress: string): Promise<string>
 	startGroupChat(wallet: BaseWallet, chat: DraftChat): Promise<string>
 
 	addMemberToGroupChat(chatId: string, users: string[]): Promise<void>

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -14,6 +14,7 @@ export interface Adapter {
 	startGroupChat(wallet: BaseWallet, chat: DraftChat): Promise<string>
 
 	addMemberToGroupChat(chatId: string, users: string[]): Promise<void>
+	saveGroupChatProfile(chatId: string): Promise<void>
 
 	sendChatMessage(wallet: BaseWallet, chatId: string, text: string): Promise<void>
 	sendData(

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -359,14 +359,6 @@ export default class WakuAdapter implements Adapter {
 
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const adapter = this
-		// const subscribeChatStore = chats.subscribe((chatData) => {
-		// 	if (adapter.updating.includes(chats)) {
-		// 		return
-		// 	}
-		// 	ws.setDoc<StorageChatEntry[]>('chats', address, Array.from(chatData.chats))
-		// })
-		// this.subscriptions.push(subscribeChatStore)
-
 		const allChats = Array.from(get(chats).chats)
 
 		// private chats
@@ -386,6 +378,12 @@ export default class WakuAdapter implements Adapter {
 		for (const groupChatId of groupChatIds) {
 			await this.subscribeToGroupChat(groupChatId, address, wakuObjectAdapter)
 		}
+
+		// chat store
+		const subscribeChatStore = chats.subscribe((chatData) => {
+			ws.setDoc<StorageChatEntry[]>('chats', address, Array.from(chatData.chats))
+		})
+		this.subscriptions.push(subscribeChatStore)
 
 		// object store
 		const objects = await readObjectStore(this.waku, address)

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -357,8 +357,6 @@ export default class WakuAdapter implements Adapter {
 		const storageChatEntries = await ws.getDoc<StorageChatEntry[]>('chats', address)
 		chats.update((state) => ({ ...state, chats: new Map(storageChatEntries), loading: false }))
 
-		console.debug({ chats: get(chats) })
-
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const adapter = this
 		const allChats = Array.from(get(chats).chats)
@@ -369,7 +367,7 @@ export default class WakuAdapter implements Adapter {
 		const lastSeenMessageTime = getLastSeenMessageTime(privateChats)
 		const now = new Date()
 		const timeFilter = {
-			startTime: new Date(lastSeenMessageTime),
+			startTime: new Date(lastSeenMessageTime + 1),
 			endTime: now,
 		}
 		await this.subscribeToPrivateMessages(address, address, wakuObjectAdapter, timeFilter)

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -29,7 +29,7 @@ function createChat(chatId: string, user: User, address: string): string {
 		messages: [],
 		users: [user, { address }],
 		name: user.name ?? user.address,
-		unread: 0, // FIXME: this should be calculated
+		unread: 0,
 	}
 	chats.createChat(chat)
 

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -184,11 +184,9 @@ export default class WakuAdapter implements Adapter {
 		if (!this.waku) {
 			this.waku = await connectWaku()
 		}
-		const storageProfile = await this.getStorageProfile(address)
-		if (!storageProfile) {
-			console.error(`invalid user to save: ${address}`)
-			return
-		}
+
+		const defaultProfile: StorageProfile = { name: name ?? address }
+		const storageProfile = (await this.getStorageProfile(address)) || defaultProfile
 
 		if (avatar) storageProfile.avatar = avatar
 		if (name) storageProfile.name = name

--- a/src/lib/adapters/waku/types.ts
+++ b/src/lib/adapters/waku/types.ts
@@ -1,5 +1,4 @@
 import type { Chat } from '$lib/stores/chat'
-import type { ObjectState } from '$lib/stores/objects'
 
 export interface StorageChat {
 	users: string[]
@@ -14,4 +13,4 @@ export interface StorageProfile {
 
 export type StorageChatEntry = [chatId: string, chat: Chat]
 
-export type StorageObjects = ObjectState
+export type StorageObjectEntry = [objectId: string, object: unknown]

--- a/src/lib/adapters/waku/types.ts
+++ b/src/lib/adapters/waku/types.ts
@@ -1,0 +1,17 @@
+import type { Chat } from '$lib/stores/chat'
+import type { ObjectState } from '$lib/stores/objects'
+
+export interface StorageChat {
+	users: string[]
+	name: string
+	avatar?: string
+}
+
+export interface StorageProfile {
+	name: string
+	avatar?: string
+}
+
+export type StorageChatEntry = [chatId: string, chat: Chat]
+
+export type StorageObjects = ObjectState

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -128,9 +128,9 @@ export async function parseQueryResults<T>(results: QueryResult): Promise<T[]> {
 		for (const messagePromise of messagePromises) {
 			console.debug({ messagePromise })
 			const message = await messagePromise
-			console.debug({ message })
 			if (message) {
 				const decodedPayload = decodeMessagePayload(message)
+				console.debug(message.timestamp)
 
 				const typedPayload = JSON.parse(decodedPayload) as T
 				typedResults.push(typedPayload)

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -25,17 +25,9 @@ const peerMultiaddr = multiaddr(
 	// '/ip4/127.0.0.1/tcp/8000/ws/p2p/16Uiu2HAm53sojJN72rFbYg6GV2LpRRER9XeWkiEAhjKy3aL9cN5Z',
 )
 
-type ContentTopic =
-	| 'private-message'
-	| 'profile'
-	| 'contact'
-	| 'chats'
-	| 'objects'
-	| 'balances'
-	| 'transactions'
-	| 'group-chats'
+export type ContentTopic = 'private-message' | 'profile' | 'chats' | 'objects' | 'group-chats'
 
-type QueryResult = AsyncGenerator<Promise<DecodedMessage | undefined>[]>
+export type QueryResult = AsyncGenerator<Promise<DecodedMessage | undefined>[]>
 
 const topicApp = 'wakuobjects-playground'
 const topicVersion = '1'
@@ -132,8 +124,11 @@ export async function readStore(
 export async function parseQueryResults<T>(results: QueryResult): Promise<T[]> {
 	const typedResults: T[] = []
 	for await (const messagePromises of results) {
+		console.debug({ messagePromises })
 		for (const messagePromise of messagePromises) {
+			console.debug({ messagePromise })
 			const message = await messagePromise
+			console.debug({ message })
 			if (message) {
 				const decodedPayload = decodeMessagePayload(message)
 

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -89,6 +89,7 @@ export async function readStore(
 ): Promise<QueryResult> {
 	const topic = getTopic(contentTopic, id)
 	const decoder = createDecoder(topic)
+
 	return waku.store.queryGenerator([decoder], storeQueryOptions)
 }
 

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -14,7 +14,6 @@ import {
 	type Callback,
 	type StoreQueryOptions,
 	type Unsubscribe,
-	PageDirection,
 } from '@waku/interfaces'
 
 const peerMultiaddr = multiaddr(
@@ -80,34 +79,6 @@ export async function storeDocument(
 	const payload = utf8ToBytes(json)
 
 	return await waku.lightPush.send(encoder, { payload })
-}
-
-export async function readLatestDocument(
-	waku: LightNode,
-	contentTopic: ContentTopic,
-	id: string,
-): Promise<unknown | undefined> {
-	const storeQueryOptions: StoreQueryOptions = {
-		pageDirection: PageDirection.BACKWARD,
-		pageSize: 1,
-	}
-	const decodedMessages = await readStore(waku, contentTopic, id, storeQueryOptions)
-	for await (const messagePromises of decodedMessages) {
-		for (const messagePromise of messagePromises) {
-			const message = await messagePromise
-			if (message) {
-				const decodedPayload = decodeMessagePayload(message)
-				// TODO HACK
-				if (!decodedPayload || decodedPayload === 'undefined') {
-					return
-				}
-
-				return JSON.parse(decodedPayload)
-			} else {
-				return
-			}
-		}
-	}
 }
 
 export async function readStore(

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -121,25 +121,6 @@ export async function readStore(
 	return waku.store.queryGenerator([decoder], storeQueryOptions)
 }
 
-export async function parseQueryResults<T>(results: QueryResult): Promise<T[]> {
-	const typedResults: T[] = []
-	for await (const messagePromises of results) {
-		console.debug({ messagePromises })
-		for (const messagePromise of messagePromises) {
-			console.debug({ messagePromise })
-			const message = await messagePromise
-			if (message) {
-				const decodedPayload = decodeMessagePayload(message)
-				console.debug(message.timestamp)
-
-				const typedPayload = JSON.parse(decodedPayload) as T
-				typedResults.push(typedPayload)
-			}
-		}
-	}
-	return typedResults
-}
-
 export function decodeMessagePayload(wakuMessage: DecodedMessage): string {
 	return bytesToUtf8(wakuMessage.payload)
 }

--- a/src/lib/adapters/waku/wakustore.ts
+++ b/src/lib/adapters/waku/wakustore.ts
@@ -100,7 +100,7 @@ export function makeWakustore(waku: LightNode) {
 	}
 
 	async function setDoc<T>(contentTopic: ContentTopic, id: string, data: T) {
-		await storeDocument(waku, contentTopic, id, data)
+		return await storeDocument(waku, contentTopic, id, data)
 	}
 
 	async function onSnapshot<T>(query: Query, callback: (value: T) => void): Promise<Unsubscribe> {

--- a/src/lib/adapters/waku/wakustore.ts
+++ b/src/lib/adapters/waku/wakustore.ts
@@ -18,11 +18,6 @@ interface Query {
 	queryOptions?: QueryOptions
 }
 
-export const latestQueryOption = {
-	pageDirection: PageDirection.BACKWARD,
-	pageSize: 1,
-}
-
 export function makeWakustore(waku: LightNode) {
 	function makeQuery(contentTopic: ContentTopic, id: string, queryOptions?: QueryOptions): Query {
 		return {

--- a/src/lib/adapters/waku/wakustore.ts
+++ b/src/lib/adapters/waku/wakustore.ts
@@ -1,0 +1,128 @@
+import type { DecodedMessage } from '@waku/sdk'
+import { decodeMessagePayload, readStore, storeDocument, subscribe } from './waku'
+import type { ContentTopic, QueryResult } from './waku'
+import {
+	PageDirection,
+	type LightNode,
+	type StoreQueryOptions,
+	type Unsubscribe,
+} from '@waku/interfaces'
+
+interface QueryOptions extends StoreQueryOptions {
+	limit?: number
+}
+
+interface Query {
+	contentTopic: ContentTopic
+	id: string
+	queryOptions?: QueryOptions
+}
+
+export const latestQueryOption = {
+	pageDirection: PageDirection.BACKWARD,
+	pageSize: 1,
+}
+
+export function makeWakustore(waku: LightNode) {
+	function makeQuery(contentTopic: ContentTopic, id: string, queryOptions?: QueryOptions): Query {
+		return {
+			contentTopic,
+			id,
+			queryOptions,
+		}
+	}
+
+	function docQuery(contentTopic: ContentTopic, id: string, queryOptions?: QueryOptions): Query {
+		return makeQuery(contentTopic, id, {
+			pageDirection: PageDirection.BACKWARD,
+			limit: 1,
+			...queryOptions,
+		})
+	}
+
+	function collectionQuery(
+		contentTopic: ContentTopic,
+		id: string,
+		queryOptions?: QueryOptions,
+	): Query {
+		return makeQuery(contentTopic, id, queryOptions)
+	}
+
+	async function parseQueryResults<T>(
+		results: QueryResult,
+		queryOptions?: QueryOptions,
+	): Promise<T[]> {
+		const typedResults: T[] = []
+		for await (const messagePromises of results) {
+			for (const messagePromise of messagePromises) {
+				const message = await messagePromise
+				if (message) {
+					const decodedPayload = decodeMessagePayload(message)
+					const timestamp = Number(message.timestamp)
+					console.debug({ decodedPayload, timestamp })
+
+					const typedPayload = JSON.parse(decodedPayload) as T
+					typedResults.push(typedPayload)
+
+					// reached the limit
+					if (
+						Number.isInteger(queryOptions?.limit) &&
+						typedResults.length === queryOptions?.limit
+					) {
+						return typedResults
+					}
+				}
+			}
+		}
+		return typedResults
+	}
+
+	async function getDoc<T>(contentTopic: ContentTopic, id: string): Promise<T> {
+		const query = docQuery(contentTopic, id)
+		const queryOptions = {
+			...query.queryOptions,
+			pageSize: query.queryOptions?.pageSize ?? query.queryOptions?.limit,
+		}
+
+		const result = await readStore(waku, query.contentTopic, query.id, queryOptions)
+		const values = await parseQueryResults<T>(result, queryOptions)
+
+		if (values.length === 1) {
+			return values[0]
+		}
+		throw 'not found'
+	}
+
+	async function setDoc<T>(contentTopic: ContentTopic, id: string, data: T) {
+		await storeDocument(waku, contentTopic, id, data)
+	}
+
+	async function onSnapshot<T>(query: Query, callback: (value: T) => void): Promise<Unsubscribe> {
+		const queryOptions = {
+			...query.queryOptions,
+			pageSize: query.queryOptions?.pageSize ?? query.queryOptions?.limit,
+		}
+		const result = await readStore(waku, query.contentTopic, query.id, queryOptions)
+		const values = await parseQueryResults<T>(result, queryOptions)
+
+		for (const value of values) {
+			callback(value)
+		}
+
+		return await subscribe(waku, query.contentTopic, query.id, (msg: DecodedMessage) => {
+			const decodedPayload = decodeMessagePayload(msg)
+			const decodedValue = JSON.parse(decodedPayload) as T
+
+			callback(decodedValue)
+		})
+	}
+
+	return {
+		makeQuery,
+		docQuery,
+		collectionQuery,
+		onSnapshot,
+		getDoc,
+		setDoc,
+	}
+}

--- a/src/lib/adapters/waku/wakustore.ts
+++ b/src/lib/adapters/waku/wakustore.ts
@@ -84,7 +84,7 @@ export function makeWakustore(waku: LightNode) {
 		return typedResults
 	}
 
-	async function getDoc<T>(contentTopic: ContentTopic, id: string): Promise<T> {
+	async function getDoc<T>(contentTopic: ContentTopic, id: string): Promise<T | undefined> {
 		const query = docQuery(contentTopic, id)
 		const queryOptions = {
 			...query.queryOptions,
@@ -97,7 +97,6 @@ export function makeWakustore(waku: LightNode) {
 		if (values.length === 1) {
 			return values[0]
 		}
-		throw 'not found'
 	}
 
 	async function setDoc<T>(contentTopic: ContentTopic, id: string, data: T) {

--- a/src/lib/adapters/waku/wakustore.ts
+++ b/src/lib/adapters/waku/wakustore.ts
@@ -58,8 +58,8 @@ export function makeWakustore(waku: LightNode) {
 				const message = await messagePromise
 				if (message) {
 					const decodedPayload = decodeMessagePayload(message)
-					const timestamp = Number(message.timestamp)
-					console.debug({ decodedPayload, timestamp })
+					// const timestamp = Number(message.timestamp)
+					// console.debug({ decodedPayload, timestamp })
 
 					const typedPayload = JSON.parse(decodedPayload) as T
 					typedResults.push(typedPayload)
@@ -118,7 +118,7 @@ export function makeWakustore(waku: LightNode) {
 	}
 
 	return {
-		makeQuery,
+		waku,
 		docQuery,
 		collectionQuery,
 		onSnapshot,

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -108,11 +108,12 @@ function createChatStore(): ChatStore {
 				if (!oldChat) {
 					return state
 				}
-				state.chats.set(chatId, update(oldChat))
+				const newMap = new Map(state.chats)
+				newMap.set(chatId, update(oldChat))
 
 				return {
 					...state,
-					chats: state.chats,
+					chats: newMap,
 				}
 			})
 		},

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -28,7 +28,7 @@ export type Message = UserMessage | DataMessage | InviteMessage
 
 export interface DraftChat {
 	users: string[]
-	name?: string
+	name: string
 	avatar?: string
 }
 
@@ -58,6 +58,22 @@ interface ChatStore extends Writable<ChatData> {
 // FIXME temporary hack
 export function isGroupChatId(id: string) {
 	return id.length === 64
+}
+
+export function getLastSeenMessageTime(chats: Chat[]) {
+	let lastMessageTime = 0
+	for (const chat of chats) {
+		const time = getLastMessageTime(chat)
+		if (time > lastMessageTime) {
+			lastMessageTime = time
+		}
+	}
+	return lastMessageTime
+}
+
+export function getLastMessageTime(chat?: Chat) {
+	const lastMessage = chat?.messages.slice(-1)[0]
+	return lastMessage ? lastMessage.timestamp : 0
 }
 
 function createChatStore(): ChatStore {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -109,58 +109,56 @@
 							userMessages.length > 0 ? userMessages[userMessages.length - 1] : undefined}
 						{@const myMessage = lastMessage && lastMessage.fromAddress === wallet.address}
 						{@const otherUser = chat.users.find((m) => m.address !== wallet.address)}
-						<li>
-							<div
-								class="chat-button"
-								on:click={() =>
-									isGroupChatId(chat.chatId)
-										? goto(ROUTES.GROUP_CHAT(chat.chatId))
-										: goto(ROUTES.CHAT(chat.chatId))}
-								on:keypress={() =>
-									isGroupChatId(chat.chatId)
-										? goto(ROUTES.GROUP_CHAT(chat.chatId))
-										: goto(ROUTES.CHAT(chat.chatId))}
-								role="button"
-								tabindex="0"
-							>
-								<Container grow>
-									<div class="chat">
-										{#if isGroupChatId(chat.chatId)}
-											<Avatar size={70} picture={chat?.avatar} />
-										{:else}
-											<Avatar size={70} picture={otherUser?.avatar} />
-										{/if}
-										<div class="content">
-											<div class="chat-info">
-												<span class="chat-name text-lg text-bold">
-													{#if isGroupChatId(chat.chatId)}
-														<span class="truncate">
+						{#if chat.chatId}
+							<li>
+								<div
+									class="chat-button"
+									on:click={() =>
+										isGroupChatId(chat.chatId)
+											? goto(ROUTES.GROUP_CHAT(chat.chatId))
+											: goto(ROUTES.CHAT(chat.chatId))}
+									on:keypress={() =>
+										isGroupChatId(chat.chatId)
+											? goto(ROUTES.GROUP_CHAT(chat.chatId))
+											: goto(ROUTES.CHAT(chat.chatId))}
+									role="button"
+									tabindex="0"
+								>
+									<Container grow>
+										<div class="chat">
+											{#if isGroupChatId(chat.chatId)}
+												<Avatar size={70} picture={chat?.avatar} />
+											{:else}
+												<Avatar size={70} picture={otherUser?.avatar} />
+											{/if}
+											<div class="content">
+												<div class="user-info">
+													<span class="username text-lg text-bold">
+														{#if isGroupChatId(chat.chatId)}
 															{chat?.name}
-														</span>
-														<Events />
-													{:else}
-														<span class="truncate">
+															<Events />
+														{:else}
 															{otherUser?.name}
-														</span>
-													{/if}
-													{#if chat.unread > 0}
-														<Badge dark>
-															{chat.unread}
-														</Badge>
-													{/if}
-												</span>
+														{/if}
+														{#if chat.unread > 0}
+															<Badge dark>
+																{chat.unread}
+															</Badge>
+														{/if}
+													</span>
+												</div>
+												<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
+													{myMessage ? 'You: ' : ''}
+													{lastMessage && lastMessage.type === 'user'
+														? lastMessage.text.substring(0, 50)
+														: 'No messages yet'}
+												</p>
 											</div>
-											<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
-												{myMessage ? 'You: ' : ''}
-												{lastMessage && lastMessage.type === 'user'
-													? lastMessage.text.substring(0, 50)
-													: 'No messages yet'}
-											</p>
 										</div>
-									</div>
-								</Container>
-							</div>
-						</li>
+									</Container>
+								</div>
+							</li>
+						{/if}
 					{/each}
 				</ul>
 			</Layout>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -132,13 +132,17 @@
 											<Avatar size={70} picture={otherUser?.avatar} />
 										{/if}
 										<div class="content">
-											<div class="user-info">
-												<span class="username text-lg text-bold">
+											<div class="chat-info">
+												<span class="chat-name text-lg text-bold">
 													{#if isGroupChatId(chat.chatId)}
-														{chat?.name}
+														<span class="truncate">
+															{chat?.name}
+														</span>
 														<Events />
 													{:else}
-														{otherUser?.name}
+														<span class="truncate">
+															{otherUser?.name}
+														</span>
 													{/if}
 													{#if chat.unread > 0}
 														<Badge dark>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,6 +24,7 @@
 	$: orderedChats = Array.from($chats.chats)
 		.map(([, chat]) => chat)
 		.sort((a, b) => lastChatMessageTimestamp(b) - lastChatMessageTimestamp(a))
+		.filter((chat) => chat.chatId) // HACK to remove early version broken group chats
 
 	function lastChatMessageTimestamp(chat: Chat) {
 		const lastMessage = chat.messages.slice(-1)[0]
@@ -109,56 +110,54 @@
 							userMessages.length > 0 ? userMessages[userMessages.length - 1] : undefined}
 						{@const myMessage = lastMessage && lastMessage.fromAddress === wallet.address}
 						{@const otherUser = chat.users.find((m) => m.address !== wallet.address)}
-						{#if chat.chatId}
-							<li>
-								<div
-									class="chat-button"
-									on:click={() =>
-										isGroupChatId(chat.chatId)
-											? goto(ROUTES.GROUP_CHAT(chat.chatId))
-											: goto(ROUTES.CHAT(chat.chatId))}
-									on:keypress={() =>
-										isGroupChatId(chat.chatId)
-											? goto(ROUTES.GROUP_CHAT(chat.chatId))
-											: goto(ROUTES.CHAT(chat.chatId))}
-									role="button"
-									tabindex="0"
-								>
-									<Container grow>
-										<div class="chat">
-											{#if isGroupChatId(chat.chatId)}
-												<Avatar size={70} picture={chat?.avatar} />
-											{:else}
-												<Avatar size={70} picture={otherUser?.avatar} />
-											{/if}
-											<div class="content">
-												<div class="user-info">
-													<span class="username text-lg text-bold">
-														{#if isGroupChatId(chat.chatId)}
-															{chat?.name}
-															<Events />
-														{:else}
-															{otherUser?.name}
-														{/if}
-														{#if chat.unread > 0}
-															<Badge dark>
-																{chat.unread}
-															</Badge>
-														{/if}
-													</span>
-												</div>
-												<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
-													{myMessage ? 'You: ' : ''}
-													{lastMessage && lastMessage.type === 'user'
-														? lastMessage.text.substring(0, 50)
-														: 'No messages yet'}
-												</p>
+						<li>
+							<div
+								class="chat-button"
+								on:click={() =>
+									isGroupChatId(chat.chatId)
+										? goto(ROUTES.GROUP_CHAT(chat.chatId))
+										: goto(ROUTES.CHAT(chat.chatId))}
+								on:keypress={() =>
+									isGroupChatId(chat.chatId)
+										? goto(ROUTES.GROUP_CHAT(chat.chatId))
+										: goto(ROUTES.CHAT(chat.chatId))}
+								role="button"
+								tabindex="0"
+							>
+								<Container grow>
+									<div class="chat">
+										{#if isGroupChatId(chat.chatId)}
+											<Avatar size={70} picture={chat?.avatar} />
+										{:else}
+											<Avatar size={70} picture={otherUser?.avatar} />
+										{/if}
+										<div class="content">
+											<div class="user-info">
+												<span class="username text-lg text-bold">
+													{#if isGroupChatId(chat.chatId)}
+														{chat?.name}
+														<Events />
+													{:else}
+														{otherUser?.name}
+													{/if}
+													{#if chat.unread > 0}
+														<Badge dark>
+															{chat.unread}
+														</Badge>
+													{/if}
+												</span>
 											</div>
+											<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
+												{myMessage ? 'You: ' : ''}
+												{lastMessage && lastMessage.type === 'user'
+													? lastMessage.text.substring(0, 50)
+													: 'No messages yet'}
+											</p>
 										</div>
-									</Container>
-								</div>
-							</li>
-						{/if}
+									</div>
+								</Container>
+							</div>
+						</li>
 					{/each}
 				</ul>
 			</Layout>

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -29,6 +29,8 @@
 	let div: HTMLElement
 	let autoscroll = true
 
+	$: chat = $chats.chats.get($page.params.id)
+
 	beforeUpdate(() => {
 		autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 74
 	})
@@ -44,6 +46,7 @@
 				behavior: 'auto',
 			})
 		}
+		chats.updateChat($page.params.id, (chat) => ({ ...chat, unread: 0 }))
 	})
 
 	$: messages = $chats.chats.get($page.params.id)?.messages || []
@@ -56,8 +59,6 @@
 		text = ''
 		loading = false
 	}
-
-	$: chat = $chats.chats.get($page.params.id)
 </script>
 
 <AuthenticatedOnly let:wallet>

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -37,6 +37,10 @@
 
 	afterUpdate(() => {
 		if (autoscroll) div.scrollTo({ top: div.scrollHeight, behavior: 'smooth' })
+
+		if (chat?.unread) {
+			chats.updateChat($page.params.id, (chat) => ({ ...chat, unread: 0 }))
+		}
 	})
 
 	onMount(() => {
@@ -46,7 +50,10 @@
 				behavior: 'auto',
 			})
 		}
-		chats.updateChat($page.params.id, (chat) => ({ ...chat, unread: 0 }))
+
+		if (chat?.unread) {
+			chats.updateChat($page.params.id, (chat) => ({ ...chat, unread: 0 }))
+		}
 	})
 
 	$: messages = $chats.chats.get($page.params.id)?.messages || []

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -34,6 +34,8 @@
 	let div: HTMLElement
 	let autoscroll = true
 
+	$: chat = $chats.chats.get($page.params.id)
+
 	beforeUpdate(() => {
 		autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 74
 	})
@@ -52,6 +54,8 @@
 				})
 			}
 		}, 0)
+
+		chats.updateChat($page.params.id, (chat) => ({ ...chat, unread: 0 }))
 	})
 
 	$: messages = $chats.chats.get($page.params.id)?.messages || []
@@ -64,8 +68,6 @@
 		text = ''
 		loading = false
 	}
-
-	$: chat = $chats.chats.get($page.params.id)
 
 	$: inviter = chat?.users.find((user) => user.address === chat?.inviter)
 

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -72,32 +72,11 @@
 	$: inviter = chat?.users.find((user) => user.address === chat?.inviter)
 
 	function join() {
-		chats.update((state) => {
-			const newChats = new Map<string, Chat>(state.chats)
-			const chat = newChats.get($page.params.id)
-			if (chat) {
-				chat.joined = true
-			}
-
-			return {
-				...state,
-				chats: newChats,
-				loading: false,
-			}
-		})
+		chats.updateChat($page.params.id, (chat) => ({ ...chat, joined: true }))
 	}
 
 	function decline() {
-		chats.update((state) => {
-			const newChats = new Map<string, Chat>(state.chats)
-			newChats.delete($page.params.id)
-
-			return {
-				...state,
-				chats: newChats,
-				loading: false,
-			}
-		})
+		chats.removeChat($page.params.id)
 		goto(ROUTES.HOME)
 	}
 </script>
@@ -149,11 +128,10 @@
 							<Checkmark />
 							Join group
 						</Button>
-						<!-- THIS BUTTON WILL BE UN-COMMENTED ONCE THE REMOVE CHAT FUNCTIONALITY IS IMPLEMENTED -->
-						<!-- <Button align="left" on:click={() => decline()}>
+						<Button align="left" on:click={() => decline()}>
 							<Close />
 							Decline
-						</Button> -->
+						</Button>
 					</Container>
 				</Container>
 			{:else}

--- a/src/routes/group/chat/[id]/edit/+page.svelte
+++ b/src/routes/group/chat/[id]/edit/+page.svelte
@@ -26,6 +26,9 @@
 	import { goto } from '$app/navigation'
 	import { getPicture, uploadPicture } from '$lib/adapters/ipfs'
 	import { onDestroy } from 'svelte'
+	import Logout from '$lib/components/icons/logout.svelte'
+	import { walletStore } from '$lib/stores/wallet'
+	import ROUTES from '$lib/routes'
 
 	$: chatId = $page.params.id
 	$: groupChat = $chats.chats.get(chatId)
@@ -74,6 +77,7 @@
 		debounceSaveProfile()
 	}
 
+	$: wallet = $walletStore.wallet
 	let timer: ReturnType<typeof setTimeout> | undefined
 
 	function saveProfileNow() {
@@ -98,6 +102,14 @@
 			saveProfileNow()
 		}
 	})
+
+	function leaveGroup() {
+		if (wallet?.address) {
+			chats.removeChat($page.params.id)
+			adapters.removeFromGroupChat($page.params.id, wallet.address)
+			goto(ROUTES.HOME)
+		}
+	}
 </script>
 
 <AuthenticatedOnly let:wallet>
@@ -194,6 +206,12 @@
 					</li>
 				{/each}
 			</ul>
+			<Container gap={12} alignItems="center" padY={24}>
+				<Button disabled={buttonDisabled} on:click={() => leaveGroup()}>
+					<Logout />
+					Leave group
+				</Button>
+			</Container>
 		</Layout>
 	{:else if screen === 'invite'}
 		<Header title="Invite to group">

--- a/src/routes/invite/[address]/+page.svelte
+++ b/src/routes/invite/[address]/+page.svelte
@@ -16,7 +16,7 @@
 	import { goto } from '$app/navigation'
 	import routes from '$lib/routes'
 	import { page } from '$app/stores'
-	import { type DraftChat, chats } from '$lib/stores/chat'
+	import { chats } from '$lib/stores/chat'
 	import adapters from '$lib/adapters'
 	import { Html5Qrcode } from 'html5-qrcode'
 	import Camera from '$lib/components/icons/camera.svelte'
@@ -101,10 +101,8 @@
 	async function startChat(address: string) {
 		loading = true
 
-		const chat: DraftChat = {
-			users: [$page.params.address, address],
-		}
-		const chatId = await adapters.startChat(address, chat)
+		const chatId = await adapters.startChat(address, $page.params.address)
+
 		loading = false
 		goto(routes.CHAT(chatId))
 	}


### PR DESCRIPTION
This is quite a major change to address many previous issues regarding reliability and consistency. Introduces a `Wakustore` type that is loosely modeled after the `Firestore` API from Firebase. There are also new types introduced to differentiate between what is stored on the waku network and what is the local svelte store.

- There is proper history management for the private and group messages and it is based on the implementation of status-web that uses the `timestamp` of the waku messages and time based queries. (Fixes #294 and #309) Previously the `Message` type also defined a timestamp, but that is set by the sender and not the node, so it is not suitable for querying. Because of this there is a hack to overwrite the `Message` timestamp with the waku message's timestamp.
- Added calculation of the unread counter and set it to zero when the user opens the chat. (Fixes #255)
- There are proper subscriptions now for private and group messages but also for the group chat itself to automatically update the group chat state when a new member is added to the group (Fixes #295 and #268)

The caveat is that the data flow is still not strictly unidirectional:
- The `chats`, `profile` and `objects` local stores are written locally and then saved to the waku network
- The `group-chats` are written to the network first and then it updates the local store in the listener callback
- The `private-message` is a mix that it's written to the network and listened to and that updates the `chats` local store

Fixes #255 
Fixes #268
Fixes #294
Fixes #295
Fixes #309
