### PR TITLE
refactor: better type safety for waku object types

### DIFF
--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -3,6 +3,7 @@ import type { Token } from '$lib/stores/balances'
 import WakuAdapter from '$lib/adapters/waku'
 import type { BaseWallet } from 'ethers'
 import type { User } from '$lib/objects/schemas'
+import type { JSONSerializable } from '$lib/objects'
 
 export interface Adapter {
 	onLogIn: (wallet: BaseWallet) => Promise<void>
@@ -23,7 +24,7 @@ export interface Adapter {
 		chatId: string,
 		objectId: string,
 		instanceId: string,
-		data: unknown,
+		data: JSONSerializable,
 	): Promise<void>
 	sendInvite(wallet: BaseWallet, chatId: string, users: string[]): Promise<void>
 
@@ -31,7 +32,7 @@ export interface Adapter {
 		address: string,
 		objectId: string,
 		instanceId: string,
-		updater: (state: unknown) => unknown,
+		updater: (state: JSONSerializable) => JSONSerializable,
 	): Promise<void>
 	sendTransaction(wallet: BaseWallet, to: string, token: Token): Promise<string>
 	estimateTransaction(wallet: BaseWallet, to: string, token: Token): Promise<Token>

--- a/src/lib/adapters/waku/types.ts
+++ b/src/lib/adapters/waku/types.ts
@@ -1,3 +1,4 @@
+import type { JSONSerializable } from '$lib/objects'
 import type { Chat } from '$lib/stores/chat'
 
 export interface StorageChat {
@@ -13,4 +14,4 @@ export interface StorageProfile {
 
 export type StorageChatEntry = [chatId: string, chat: Chat]
 
-export type StorageObjectEntry = [objectId: string, object: unknown]
+export type StorageObjectEntry = [objectId: string, object: JSONSerializable]

--- a/src/lib/objects/chat.svelte
+++ b/src/lib/objects/chat.svelte
@@ -5,7 +5,7 @@
 	import adapter from '$lib/adapters'
 	import { page } from '$app/stores'
 	import { profile } from '$lib/stores/profile'
-	import type { WakuObjectArgs } from '.'
+	import type { JSONSerializable, WakuObjectArgs } from '.'
 	import { lookup } from './lookup'
 	import type { User } from './schemas'
 	import { makeWakuObjectAdapter } from './adapter'
@@ -18,7 +18,7 @@
 
 	const component = lookup(message.objectId)?.wakuObject
 
-	let store: unknown
+	let store: JSONSerializable | undefined
 	$: store = $objectStore.objects.get(objectKey(message.objectId, message.instanceId))
 	const wallet = $walletStore.wallet
 	if (!wallet) {
@@ -38,12 +38,12 @@
 
 	$: tokens = $balanceStore.balances
 
-	function updateStore(updater: (state: unknown) => unknown) {
+	function updateStore(updater: (state: JSONSerializable) => JSONSerializable) {
 		adapter.updateStore(address, message.objectId, message.instanceId, updater)
 	}
 
 	let args: WakuObjectArgs
-	$: if (userProfile) {
+	$: if (store && userProfile) {
 		const wakuObjectAdapter = makeWakuObjectAdapter(adapter, wallet)
 		args = {
 			instanceId: message.instanceId,
@@ -51,7 +51,7 @@
 			users,
 			tokens,
 			store,
-			send: (data: unknown) =>
+			send: (data: JSONSerializable) =>
 				adapter.sendData(wallet, chatId, message.objectId, message.instanceId, data),
 			updateStore,
 			...wakuObjectAdapter,

--- a/src/lib/objects/hello-world/hello-world-receiver.svelte
+++ b/src/lib/objects/hello-world/hello-world-receiver.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import Button from '$lib/components/button.svelte'
 	import ChatMessage from '$lib/components/chat-message.svelte'
+	import type { HelloWorldStore } from '.'
 
 	export let instanceId: string
 	export let name: string | undefined
 	export let ownName: string
-	export let send: (data: unknown) => Promise<void>
-	export let updateStore: (updater: (state: unknown) => unknown) => void
+	export let send: (data: HelloWorldStore) => Promise<void>
+	export let updateStore: (updater: (state: HelloWorldStore) => HelloWorldStore) => void
 
 	async function sendName() {
 		updateStore(() => ({ name: ownName }))

--- a/src/lib/objects/hello-world/hello-world.svelte
+++ b/src/lib/objects/hello-world/hello-world.svelte
@@ -6,7 +6,7 @@
 	import HelloWorldSender from './hello-world-sender.svelte'
 
 	export let message: DataMessage
-	export let args: WakuObjectArgs
+	export let args: WakuObjectArgs<HelloWorldStore>
 
 	$: helloWorldStore = args.store as HelloWorldStore | undefined
 	$: address = args.profile.address

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -14,8 +14,18 @@ export interface WakuObjectAdapter {
 	getContract(address: string, abi: Interface): Contract
 }
 
-export interface WakuObjectArgs<StoreType = unknown, DataMessageType extends object = unknown>
-	extends WakuObjectAdapter {
+type JSONSerializable =
+	| string
+	| number
+	| boolean
+	| null
+	| JSONValue[]
+	| { [key: string]: JSONValue }
+
+export interface WakuObjectArgs<
+	StoreType extends JSONSerializable = JSONSerializable,
+	DataMessageType extends JSONSerializable = JSONSerializable,
+> extends WakuObjectAdapter {
 	readonly instanceId: string
 	readonly profile: User
 	readonly users: User[]
@@ -30,7 +40,7 @@ export interface WakuObjectArgs<StoreType = unknown, DataMessageType extends obj
 	onViewChange: (view: string) => void
 }
 
-type WakuStoreType = unknown
+type WakuStoreType = JSONSerializable
 
 interface WakuObjectDescriptor {
 	readonly objectId: string

--- a/src/lib/objects/ui.svelte
+++ b/src/lib/objects/ui.svelte
@@ -3,7 +3,7 @@
 	import { lookup } from './lookup'
 	import { balanceStore, type Token } from '$lib/stores/balances'
 	import { chats, type Chat } from '$lib/stores/chat'
-	import type { WakuObjectArgs } from '.'
+	import type { JSONSerializable, WakuObjectArgs } from '.'
 	import { profile } from '$lib/stores/profile'
 	import { makeWakuObjectAdapter } from './adapter'
 	import type { User } from '$lib/types'
@@ -21,7 +21,7 @@
 	const component = lookup(objectId)?.standalone
 
 	let args: WakuObjectArgs
-	let store: unknown
+	let store: JSONSerializable | undefined
 	let tokens: Token[]
 	let chat: Chat | undefined
 	let userProfile: User
@@ -29,11 +29,11 @@
 
 	$: loading = $chats.loading || $objectStore.loading || $balanceStore.loading
 
-	function send(data: unknown): Promise<void> {
+	function send(data: JSONSerializable): Promise<void> {
 		return adapter.sendData(wallet, chatId, objectId, instanceId, data)
 	}
 
-	function updateStore(updater: (state: unknown) => unknown) {
+	function updateStore(updater: (state: JSONSerializable) => JSONSerializable) {
 		adapter.updateStore(wallet.address, objectId, instanceId, updater)
 	}
 
@@ -53,7 +53,7 @@
 		chat = $chats.chats.get(chatId)
 	}
 
-	$: if (chat) {
+	$: if (store && chat) {
 		users = chat.users
 
 		const wakuObjectAdapter = makeWakuObjectAdapter(adapter, wallet)

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -1,3 +1,4 @@
+import type { JSONSerializable } from '$lib/objects'
 import type { User } from '$lib/types'
 import { writable, type Writable } from 'svelte/store'
 
@@ -8,7 +9,7 @@ export interface UserMessage {
 	text: string
 }
 
-export interface DataMessage<T = unknown> {
+export interface DataMessage<T extends JSONSerializable = JSONSerializable> {
 	type: 'data'
 	timestamp: number
 	fromAddress: string

--- a/src/lib/stores/objects.ts
+++ b/src/lib/stores/objects.ts
@@ -1,9 +1,10 @@
+import type { JSONSerializable } from '$lib/objects'
 import { writable, type Writable } from 'svelte/store'
 
 export interface ObjectState {
 	loading: boolean
 	lastUpdated: number
-	objects: Map<string, unknown>
+	objects: Map<string, JSONSerializable>
 	error?: Error
 }
 
@@ -17,7 +18,7 @@ export function objectKey(objectId: string, instanceId: string): string {
 function createObjectStore(): ObjectStore {
 	const store = writable<ObjectState>({
 		loading: true,
-		objects: new Map<string, unknown>(),
+		objects: new Map<string, JSONSerializable>(),
 		lastUpdated: 0,
 	})
 	return {

--- a/src/routes/chat/[id]/object/new/+page.svelte
+++ b/src/routes/chat/[id]/object/new/+page.svelte
@@ -17,6 +17,7 @@
 	import { wakuObjectList } from '$lib/objects/lookup'
 	import AuthenticatedOnly from '$lib/components/authenticated-only.svelte'
 	import Layout from '$lib/components/layout.svelte'
+	import type { JSONSerializable } from '$lib/objects'
 
 	const objects = wakuObjectList.map((object) => ({
 		...object,
@@ -34,7 +35,7 @@
 	let loading = false
 	let text = ''
 
-	const createObject = async <T>(objectId: string, t: T) => {
+	const createObject = async <T extends JSONSerializable>(objectId: string, t: T) => {
 		// TODO random
 		const genRanHex = (size: number) =>
 			[...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('')
@@ -42,7 +43,7 @@
 		await sendData(objectId, instanceId, t)
 	}
 
-	const sendData = async (objectId: string, instanceId: string, data: unknown) => {
+	const sendData = async (objectId: string, instanceId: string, data: JSONSerializable) => {
 		loading = true
 		const wallet = $walletStore.wallet
 		if (!wallet) throw new Error('no wallet')


### PR DESCRIPTION
The main goal here was to eliminate the `unknown` types from the Waku Object interface. The solution was to introduce a new type called `JSONSerializable` because essentially we need to serialize these objects to JSON in order to store and transmit. Therefore this can help eliminating the usage of types which cannot be serialized to JSON (e.g. `Date`, functions, etc.) at the type system level.