### PR TITLE
fix: JSONSerializable type

### DIFF
--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -19,8 +19,8 @@ type JSONSerializable =
 	| number
 	| boolean
 	| null
-	| JSONValue[]
-	| { [key: string]: JSONValue }
+	| JSONSerializable[]
+	| Partial<Record<symbol, JSONSerializable>>
 
 export interface WakuObjectArgs<
 	StoreType extends JSONSerializable = JSONSerializable,


### PR DESCRIPTION
There was a bug in the type definition of `JSONSerializable` type that was not caught by the review, neither by the Typescript compiler :grin: . The `JSONValue` was the original name of the `JSONSerializable` but after renaming I forgot to update all occurrences.

After fixing that there was a compiler error of using `{ [key: string]: JSONSerializable }` so I replaced it with a `Record` type instead.