### PR TITLE
fix: undefined store

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -101,9 +101,6 @@ async function executeOnDataMessage(
 		const objects = wakuObjectStore.objects
 		const updateStore = (updater: (_store: JSONSerializable) => JSONSerializable) => {
 			const store = objects.get(key)
-			if (!store) {
-				return
-			}
 			const newStore = updater(store)
 			const newObjects = new Map(objects)
 			newObjects.set(key, newStore)
@@ -114,10 +111,6 @@ async function executeOnDataMessage(
 			}))
 		}
 		const store = objects.get(key)
-		if (!store) {
-			return
-		}
-
 		await descriptor.onMessage(address, adapter, store, updateStore, chatMessage)
 	}
 }

--- a/src/lib/objects/chat.svelte
+++ b/src/lib/objects/chat.svelte
@@ -43,7 +43,7 @@
 	}
 
 	let args: WakuObjectArgs
-	$: if (store && userProfile) {
+	$: if (userProfile) {
 		const wakuObjectAdapter = makeWakuObjectAdapter(adapter, wallet)
 		args = {
 			instanceId: message.instanceId,

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -14,7 +14,7 @@ export interface WakuObjectAdapter {
 	getContract(address: string, abi: Interface): Contract
 }
 
-type JSONSerializable =
+export type JSONSerializable =
 	| string
 	| number
 	| boolean

--- a/src/lib/objects/ui.svelte
+++ b/src/lib/objects/ui.svelte
@@ -53,8 +53,6 @@
 		chat = $chats.chats.get(chatId)
 	}
 
-	$: console.debug({ store, chat, users, userProfile })
-
 	$: if (chat) {
 		users = chat.users
 

--- a/src/lib/objects/ui.svelte
+++ b/src/lib/objects/ui.svelte
@@ -53,7 +53,9 @@
 		chat = $chats.chats.get(chatId)
 	}
 
-	$: if (store && chat) {
+	$: console.debug({ store, chat, users, userProfile })
+
+	$: if (chat) {
 		users = chat.users
 
 		const wakuObjectAdapter = makeWakuObjectAdapter(adapter, wallet)


### PR DESCRIPTION
There is a regression caused by the type-safety refactor and it makes Payggy (and any other WO) using the object store to fail. 

This is just a temporary fix to make it work again, however this is still not typesafe and not completely correct, because `store` can be `undefined`, but it is not a valid `JSONSerializable` value. Still it works for now and in a later PR it can be fixed properly.