### PR TITLE
fix: more robust message handling

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -168,7 +168,7 @@
 											<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
 												{senderName}
 												{lastMessage && lastMessage.type === 'user'
-													? lastMessage.text.substring(0, 50)
+													? lastMessage.text?.substring(0, 50)
 													: 'No messages yet'}
 											</p>
 										</div>

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -95,7 +95,7 @@
 						<div class="messages-inner">
 							<!-- Chat bubbles -->
 							{#each messages as message}
-								{#if message.type === 'user' && message.text.length > 0}
+								{#if message.type === 'user' && message.text?.length > 0}
 									<ChatMessage
 										myMessage={message.fromAddress === wallet.address ? true : false}
 										bubble

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -152,7 +152,7 @@
 							<div class="messages-inner">
 								<!-- Chat bubbles -->
 								{#each messages as message, i}
-									{#if message.type === 'user' && message.text.length > 0}
+									{#if message.type === 'user' && message.text?.length > 0}
 										{@const sameSender = messages[i].fromAddress === messages[i - 1]?.fromAddress}
 										{@const lastMessage =
 											i + 1 === messages.length ||


### PR DESCRIPTION
Currently it is possible to receive messages where the text is undefined (the current bot version sometimes sends like that). 

The nice solution would be to validate incoming messages. In the meanwhile this is a workaround to make the page load if that happens.