### PR TITLE
fix: html entities in chat list

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -167,7 +167,7 @@
 											</div>
 											<p class={`message text-serif ${myMessage ? 'my-message' : ''}`}>
 												{senderName}
-												{lastMessage && lastMessage.type === 'user'
+												{@html lastMessage && lastMessage.type === 'user'
 													? lastMessage.text?.substring(0, 50)
 													: 'No messages yet'}
 											</p>


### PR DESCRIPTION
The chat bots use HTML entities for special characters and they were not correctly displayed in the chat list. This PR fixes that.

![Screenshot from 2023-09-04 10-43-00](https://github.com/logos-innovation-lab/waku-objects-playground/assets/230163/3723a6c7-22f8-4e7e-b588-6f2fdfef7831)
