### PR TITLE
chore: log lightpush issues

### DIFF
--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -78,7 +78,10 @@ export async function storeDocument(
 	const json = JSON.stringify(document)
 	const payload = utf8ToBytes(json)
 
-	return await waku.lightPush.send(encoder, { payload })
+	const { error } = await waku.lightPush.send(encoder, { payload })
+	if (error) {
+		console.error(error)
+	}
 }
 
 export async function readStore(
@@ -103,5 +106,8 @@ export async function sendMessage(waku: LightNode, id: string, message: unknown)
 	const contentTopic = getTopic('private-message', id)
 	const encoder = createEncoder({ contentTopic })
 
-	return await waku.lightPush.send(encoder, { payload })
+	const { error } = await waku.lightPush.send(encoder, { payload })
+	if (error) {
+		console.error(error)
+	}
 }


### PR DESCRIPTION
This logs `lighPush.send` errors to debug issues related to disconnections. We should probably throw this error at some point and handle it in the UI.