### PR TITLE
fix: entry script CSP for Firefox

### DIFF
--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -53,7 +53,7 @@ export const getNPMObject = async (
 		if (!added['script-src']) {
 			added['script-src'] = ''
 		}
-		added['script-src'] += ` ${window.location.origin + script}`
+		added['script-src'] += ` ${script}`
 
 		return {
 			script,

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -53,6 +53,7 @@ export const getNPMObject = async (
 		if (!added['script-src']) {
 			added['script-src'] = ''
 		}
+		added['script-src'] += ` ${window.location.origin + script}`
 
 		return {
 			script,

--- a/src/lib/objects/external/template.html
+++ b/src/lib/objects/external/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<!-- <meta http-equiv="Content-Security-Policy" content="__CSP__" /> -->
+		<meta http-equiv="Content-Security-Policy" content="__CSP__" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<style>
 			* {


### PR DESCRIPTION
We should also remove the `'self'` in `script-src` for the Waku Objects, as it's no longer necessary.

Ideally, the entry script would be hashed and added to `src-script` with `sha256-*`, like we do for the embeds, but that doesn't seem to work for some reason? The current solution might be a bit too open and allow Waku Objects to import Playground scripts, which might be problematic.