### PR TITLE
feat: external object props

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -28,7 +28,6 @@ const config: KnipConfig = {
 	},
 	ignoreExportsUsedInFile: true,
 	ignoreBinaries: ['docker'],
-	ignoreDependencies: ['@waku-objects/sandbox-example'],
 }
 
 export default config

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.61.0",
 		"@typescript-eslint/parser": "^5.61.0",
 		"@waku-objects/luminance": "^2.0.1",
-		"@waku-objects/sandbox-example": "file:../waku-objects/objects/sandbox-example",
+		"@waku-objects/sandbox-example": "^0.4.0",
 		"@waku/interfaces": "^0.0.15",
 		"@waku/sdk": "^0.0.16",
 		"copy-to-clipboard": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.61.0",
 		"@typescript-eslint/parser": "^5.61.0",
 		"@waku-objects/luminance": "^2.0.1",
-		"@waku-objects/sandbox-example": "^0.3.0",
+		"@waku-objects/sandbox-example": "file:../waku-objects/objects/sandbox-example",
 		"@waku/interfaces": "^0.0.15",
 		"@waku/sdk": "^0.0.16",
 		"copy-to-clipboard": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ devDependencies:
     specifier: ^2.0.1
     version: 2.0.1
   '@waku-objects/sandbox-example':
-    specifier: ^0.3.0
-    version: 0.3.0
+    specifier: file:../waku-objects/objects/sandbox-example
+    version: link:../waku-objects/objects/sandbox-example
   '@waku/interfaces':
     specifier: ^0.0.15
     version: 0.0.15
@@ -2491,29 +2491,8 @@ packages:
       pretty-format: 29.6.2
     dev: true
 
-  /@waku-objects/adapter@0.3.0:
-    resolution: {integrity: sha512-iRtyMGIk1j5feNuEQXOhX+F9dFExR43jb3PH/Gfyly+VZtddjU3YNOTj8nx0/Wqk3tMfxdHuY9iYiqjhRVf71A==}
-    dependencies:
-      ethers: 6.7.1
-      p-defer: 4.0.0
-      zod: 3.22.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
   /@waku-objects/luminance@2.0.1:
     resolution: {integrity: sha512-/zmMsR9nXXzV5uwpMYxOjMzSOOyQFi6vqMuPBkvF0+XCnOHXFR6y/ONX2DeBkMLkvoueDG8rwADvZpyyvU3bWA==}
-    dev: true
-
-  /@waku-objects/sandbox-example@0.3.0:
-    resolution: {integrity: sha512-hlQ+Kf+TBhVTr7SBj2BKMMK4hN1YoZtOdEHbk7dtlY2h808ANccXA5hKviBNmnoMCjToZ8jEr/SC6A9X8oDQ1g==}
-    dependencies:
-      '@waku-objects/adapter': 0.3.0
-      ethers: 6.7.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
     dev: true
 
   /@waku/core@0.0.20(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2):
@@ -3748,22 +3727,6 @@ packages:
 
   /ethers@6.6.4:
     resolution: {integrity: sha512-r3myN2hEnydmu23iiIj5kjWnCh5JNzlqrE/z+Kw5UqH173F+JOWzU6qkFB4HVC50epgxzKSL2Hq1oNXA877vwQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.2
-      '@noble/hashes': 1.1.2
-      '@noble/secp256k1': 1.7.1
-      '@types/node': 18.15.13
-      aes-js: 4.0.0-beta.5
-      tslib: 2.4.0
-      ws: 8.5.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
-  /ethers@6.7.1:
-    resolution: {integrity: sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.9.2
@@ -7009,8 +6972,4 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-    dev: true
-
-  /zod@3.22.2:
-    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ devDependencies:
     specifier: ^2.0.1
     version: 2.0.1
   '@waku-objects/sandbox-example':
-    specifier: file:../waku-objects/objects/sandbox-example
-    version: link:../waku-objects/objects/sandbox-example
+    specifier: ^0.4.0
+    version: 0.4.0
   '@waku/interfaces':
     specifier: ^0.0.15
     version: 0.0.15
@@ -2491,8 +2491,29 @@ packages:
       pretty-format: 29.6.2
     dev: true
 
+  /@waku-objects/adapter@0.4.0:
+    resolution: {integrity: sha512-8eojpU3hg+QFrB0ZKCkYvgMYue4aSC+1Ejf7+875gLLeTHDZofU3a85ZJZnu3WcS+v1pMMehNyUWSiPjRRpkXw==}
+    dependencies:
+      ethers: 6.7.1
+      p-defer: 4.0.0
+      zod: 3.22.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
   /@waku-objects/luminance@2.0.1:
     resolution: {integrity: sha512-/zmMsR9nXXzV5uwpMYxOjMzSOOyQFi6vqMuPBkvF0+XCnOHXFR6y/ONX2DeBkMLkvoueDG8rwADvZpyyvU3bWA==}
+    dev: true
+
+  /@waku-objects/sandbox-example@0.4.0:
+    resolution: {integrity: sha512-Op34sv2QliveTFfDQ2EXf7YP3rXO3oJhSDdQC7NenYBarzjSChlu2C1AVVdU0tv8b/wNmlvZ+4Ky0QHvLkOkqA==}
+    dependencies:
+      '@waku-objects/adapter': 0.4.0
+      ethers: 6.6.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /@waku/core@0.0.20(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2):
@@ -3727,6 +3748,22 @@ packages:
 
   /ethers@6.6.4:
     resolution: {integrity: sha512-r3myN2hEnydmu23iiIj5kjWnCh5JNzlqrE/z+Kw5UqH173F+JOWzU6qkFB4HVC50epgxzKSL2Hq1oNXA877vwQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.2
+      '@noble/hashes': 1.1.2
+      '@noble/secp256k1': 1.7.1
+      '@types/node': 18.15.13
+      aes-js: 4.0.0-beta.5
+      tslib: 2.4.0
+      ws: 8.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /ethers@6.7.1:
+    resolution: {integrity: sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.9.2
@@ -6972,4 +7009,8 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: true
+
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: true

--- a/src/lib/objects/chat.svelte
+++ b/src/lib/objects/chat.svelte
@@ -17,7 +17,7 @@
 	export let message: DataMessage
 	export let users: User[]
 
-	const { wakuObject, customArgs } = lookup(message.objectId) || {}
+	const { wakuObject } = lookup(message.objectId) || {}
 
 	let store: JSONSerializable | undefined
 	$: store = $objectStore.objects.get(objectKey(message.objectId, message.instanceId))
@@ -78,4 +78,4 @@
 	}
 </script>
 
-<svelte:component this={wakuObject} {message} {args} {customArgs} />
+<svelte:component this={wakuObject} {message} {args} />

--- a/src/lib/objects/external/chat.svelte
+++ b/src/lib/objects/external/chat.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { DataMessage } from '$lib/stores/chat'
+	import type { WakuObjectArgs } from '..'
+	import IframeComponent from './iframe.svelte'
+
+	// Exports
+	export let message: DataMessage
+	export let args: WakuObjectArgs
+</script>
+
+<IframeComponent {message} {args} />

--- a/src/lib/objects/external/dispatch.ts
+++ b/src/lib/objects/external/dispatch.ts
@@ -6,6 +6,7 @@ import type {
 	JSONValue,
 	WakuObjectAdapter,
 	WakuObjectArgs,
+	WakuObjectContextProps,
 	WakuObjectState,
 } from '..'
 import type { Token } from '../schemas'
@@ -39,6 +40,12 @@ export interface IframeDataMessage {
 	type: 'iframe-data-message'
 	message: DataMessage
 	state: WakuObjectState
+}
+
+export interface IframeContextChange {
+	type: 'iframe-context-change'
+	state: WakuObjectState
+	context: WakuObjectContextProps
 }
 
 interface IframeDispatcher {

--- a/src/lib/objects/external/iframe.svelte
+++ b/src/lib/objects/external/iframe.svelte
@@ -84,11 +84,23 @@
 	}
 
 	function updateContext(force = false) {
-		const { chatId, objectId, instanceId, profile, users, tokens, view, store } = args
+		const {
+			chatId,
+			chatName,
+			objectId,
+			instanceId,
+			profile,
+			users,
+			tokens,
+			view,
+			viewParams,
+			store,
+		} = args
 		const iframeContextChange: IframeContextChange = {
 			type: 'iframe-context-change',
 			state: {
 				chatId,
+				chatName,
 				objectId,
 				instanceId,
 				profile,
@@ -97,6 +109,7 @@
 			},
 			context: {
 				view,
+				viewParams,
 				store,
 			},
 		}

--- a/src/lib/objects/external/index.ts
+++ b/src/lib/objects/external/index.ts
@@ -10,13 +10,14 @@ export const getExternalDescriptor = (
 	name: string,
 	description: string,
 	logo: string,
+	hasStandalone?: boolean,
 ): WakuObjectSvelteDescriptor => ({
 	objectId,
 	name,
 	description,
 	logo,
 	wakuObject: ChatComponent,
-	standalone: StandaloneComponent,
+	standalone: hasStandalone ? StandaloneComponent : undefined,
 	onMessage: async (message, args) => {
 		const iframeDataMessage: IframeDataMessage = {
 			type: 'iframe-data-message',

--- a/src/lib/objects/external/index.ts
+++ b/src/lib/objects/external/index.ts
@@ -15,19 +15,13 @@ export const getExternalDescriptor = (
 	description,
 	logo,
 	wakuObject: IframeComponent,
-	customArgs: { name: objectId },
 	onMessage: async (message, args) => {
-		const window = instanceWindowMap.get(message.instanceId)
-		if (!window) {
-			return
-		}
-
 		const iframeDataMessage: IframeDataMessage = {
 			type: 'iframe-data-message',
 			message,
 			state: args,
 		}
-		window.postMessage(iframeDataMessage, { targetOrigin: '*' })
+		postWindowMessage(message.instanceId, iframeDataMessage)
 	},
 })
 
@@ -41,4 +35,11 @@ export function registerWindow(instanceId: string, window: Window) {
 
 export function unregisterWindow(instanceId: string) {
 	instanceWindowMap.delete(instanceId)
+}
+
+export function postWindowMessage(instanceId: string, message: unknown) {
+	const window = instanceWindowMap.get(instanceId)
+	if (window) {
+		window.postMessage(message, { targetOrigin: '*' })
+	}
 }

--- a/src/lib/objects/external/index.ts
+++ b/src/lib/objects/external/index.ts
@@ -1,6 +1,7 @@
 import type { WakuObjectSvelteDescriptor } from '..'
 import type { IframeDataMessage } from './dispatch'
-import IframeComponent from './iframe.svelte'
+import ChatComponent from './chat.svelte'
+import StandaloneComponent from './standalone.svelte'
 
 const instanceWindowMap = new Map<string, Window>()
 
@@ -14,7 +15,8 @@ export const getExternalDescriptor = (
 	name,
 	description,
 	logo,
-	wakuObject: IframeComponent,
+	wakuObject: ChatComponent,
+	standalone: StandaloneComponent,
 	onMessage: async (message, args) => {
 		const iframeDataMessage: IframeDataMessage = {
 			type: 'iframe-data-message',

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -16,6 +16,7 @@ export type Csp = {
 
 export type WakuObject = {
 	name: string
+	standalone?: boolean
 	csp: Csp
 }
 
@@ -28,6 +29,7 @@ export type LoadedObject = {
 	script: string
 	csp: string
 	name: string
+	className: string
 }
 
 const DEFAULT_CSP: Csp = {
@@ -44,7 +46,10 @@ const formatCsp = (csp: Csp, add?: Csp): string => {
 		.join('; ')
 }
 
-export const getNPMObject = async (module: string): Promise<LoadedObject | null> => {
+export const getNPMObject = async (
+	module: string,
+	className: 'chat' | 'standalone',
+): Promise<LoadedObject | null> => {
 	try {
 		const object = (await objects[`/node_modules/${module}/object/metadata.json`]()) as WakuObject
 		const script = await scripts[`/node_modules/${module}/object/index.js`]()
@@ -58,6 +63,7 @@ export const getNPMObject = async (module: string): Promise<LoadedObject | null>
 			script,
 			csp: formatCsp(object.csp, added),
 			name: object.name,
+			className,
 		}
 	} catch (err) {
 		console.error(err)

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -20,11 +20,6 @@ export type WakuObject = {
 	csp: Csp
 }
 
-export type Embed = {
-	message: string
-	sha256: string
-}
-
 export type LoadedObject = {
 	script: string
 	csp: string

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -1,5 +1,3 @@
-import type { DataMessage } from '$lib/stores/chat'
-
 // Not sure how inefficient this is
 const scripts = import.meta.glob('/node_modules/**/object/index.js', {
 	as: 'url',
@@ -30,7 +28,6 @@ export type LoadedObject = {
 	script: string
 	csp: string
 	name: string
-	embed: Embed
 }
 
 const DEFAULT_CSP: Csp = {
@@ -47,50 +44,20 @@ const formatCsp = (csp: Csp, add?: Csp): string => {
 		.join('; ')
 }
 
-const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
-	let binary = ''
-	const bytes = new Uint8Array(buffer)
-	const len = bytes.byteLength
-
-	for (let i = 0; i < len; i++) {
-		binary += String.fromCharCode(bytes[i])
-	}
-
-	return window.btoa(binary)
-}
-
-const getEmbed = async (dataMessage: DataMessage): Promise<Embed> => {
-	const message = `
-		window.wakuObject = {}
-		window.wakuObject.message = JSON.parse('${JSON.stringify(dataMessage)}')
-	`
-
-	const utf8 = new TextEncoder().encode(message)
-	const hashBuffer = await crypto.subtle.digest('SHA-256', utf8)
-
-	return { message, sha256: arrayBufferToBase64(hashBuffer) }
-}
-
-export const getNPMObject = async (
-	module: string,
-	message: DataMessage,
-): Promise<LoadedObject | null> => {
+export const getNPMObject = async (module: string): Promise<LoadedObject | null> => {
 	try {
 		const object = (await objects[`/node_modules/${module}/object/metadata.json`]()) as WakuObject
 		const script = await scripts[`/node_modules/${module}/object/index.js`]()
-		const embed = await getEmbed(message)
 
 		const added = { ...DEFAULT_CSP } as Csp
 		if (!added['script-src']) {
 			added['script-src'] = ''
 		}
-		added['script-src'] += ` 'sha256-${embed.sha256}'`
 
 		return {
 			script,
 			csp: formatCsp(object.csp, added),
 			name: object.name,
-			embed: embed,
 		}
 	} catch (err) {
 		console.error(err)

--- a/src/lib/objects/external/standalone.svelte
+++ b/src/lib/objects/external/standalone.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import Layout from '$lib/components/layout.svelte'
+	import Header from '$lib/components/header.svelte'
+	import Button from '$lib/components/button.svelte'
+	import ChevronLeft from '$lib/components/icons/chevron-left.svelte'
+	import Close from '$lib/components/icons/close.svelte'
+
+	import type { WakuObjectArgs } from '..'
+	import IframeComponent from './iframe.svelte'
+	import { getNPMObject, type LoadedObject } from './lib'
+
+	// Exports
+	export let args: WakuObjectArgs
+
+	let object: LoadedObject | null
+
+	$: args && getNPMObject(args.objectId).then((result) => (object = result))
+	$: isGroupchat = args.users.length !== 2
+
+	// Utility function which makes it easier to handle history for closing the object
+	const exitObject = (depth: number) => () => history.go(isGroupchat ? -depth - 1 : -depth)
+</script>
+
+{#if object}
+	<Layout>
+		<svelte:fragment slot="header">
+			<Header title={object.name}>
+				<Button slot="left" variant="icon" on:click={() => history.back()}>
+					<ChevronLeft />
+				</Button>
+				<Button slot="right" variant="icon" on:click={exitObject(1)}>
+					<Close />
+				</Button>
+			</Header>
+		</svelte:fragment>
+		<IframeComponent {args} message={undefined} />
+	</Layout>
+{/if}

--- a/src/lib/objects/external/standalone.svelte
+++ b/src/lib/objects/external/standalone.svelte
@@ -2,23 +2,25 @@
 	import Layout from '$lib/components/layout.svelte'
 	import Header from '$lib/components/header.svelte'
 	import Button from '$lib/components/button.svelte'
+	import Container from '$lib/components/container.svelte'
 	import ChevronLeft from '$lib/components/icons/chevron-left.svelte'
 	import Close from '$lib/components/icons/close.svelte'
 
 	import type { WakuObjectArgs } from '..'
 	import IframeComponent from './iframe.svelte'
 	import { getNPMObject, type LoadedObject } from './lib'
+	import { isGroupChatId } from '$lib/stores/chat'
 
 	// Exports
 	export let args: WakuObjectArgs
 
 	let object: LoadedObject | null
 
-	$: args && getNPMObject(args.objectId).then((result) => (object = result))
-	$: isGroupchat = args.users.length !== 2
+	$: args && getNPMObject(args.objectId, 'standalone').then((result) => (object = result))
 
 	// Utility function which makes it easier to handle history for closing the object
-	const exitObject = (depth: number) => () => history.go(isGroupchat ? -depth - 1 : -depth)
+	const exitObject = (depth: number) => () =>
+		history.go(isGroupChatId(args.chatId) ? -depth - 1 : -depth)
 </script>
 
 {#if object}
@@ -33,6 +35,8 @@
 				</Button>
 			</Header>
 		</svelte:fragment>
-		<IframeComponent {args} message={undefined} />
+		<Container gap={24} justify="center" padX={24}>
+			<IframeComponent {args} message={undefined} />
+		</Container>
 	</Layout>
 {/if}

--- a/src/lib/objects/external/template.html
+++ b/src/lib/objects/external/template.html
@@ -3,15 +3,15 @@
 	<head>
 		<meta charset="UTF-8" />
 		<!-- <meta http-equiv="Content-Security-Policy" content="__CSP__" /> -->
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<!-- <meta name="viewport" content="width=device-width, initial-scale=1.0" /> -->
 		<style>
 			* {
 				overflow: hidden;
 				margin: 0;
 			}
 
-			html {
-				text-align: center;
+			body {
+				display: flex;
 			}
 		</style>
 	</head>

--- a/src/lib/objects/external/template.html
+++ b/src/lib/objects/external/template.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<!-- <meta http-equiv="Content-Security-Policy" content="__CSP__" /> -->
-		<!-- <meta name="viewport" content="width=device-width, initial-scale=1.0" /> -->
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<style>
 			* {
 				overflow: hidden;
@@ -19,7 +19,6 @@
 		<div id="app"></div>
 		<script type="module" src="__URL__"></script>
 		<!-- prettier-ignore -->
-		<script>__EMBED__</script>
 		<script>
 			const postSize = () => {
 				const { scrollWidth, scrollHeight } = document.body

--- a/src/lib/objects/external/template.html
+++ b/src/lib/objects/external/template.html
@@ -16,7 +16,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="app"></div>
+		<div id="app" class="__CLASS__"></div>
 		<script type="module" src="__URL__"></script>
 		<!-- prettier-ignore -->
 		<script>

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -36,24 +36,33 @@ export interface WakuObjectState {
 type StoreType = JSONSerializable
 type DataMessageType = JSONSerializable
 
-export interface WakuObjectContextProps<ViewType extends string = string> {
+export interface WakuObjectContextProps<
+	StoreType = JSONSerializable,
+	ViewType extends string = string,
+> {
 	readonly store?: StoreType
 	readonly view?: ViewType
+	readonly viewParams: string[] // Other path params after the screen
 }
 
-export interface WakuObjectContext<ViewType extends string = string> extends WakuObjectContextProps<ViewType>, WakuObjectAdapter {
+export interface WakuObjectContext<
+	StoreType = JSONSerializable,
+	DataMessageType = JSONSerializable,
+	ViewType extends string = string,
+> extends WakuObjectContextProps<StoreType, ViewType>,
+		WakuObjectAdapter {
 	updateStore: (updater: (state?: StoreType) => StoreType) => void
 
 	send: (data: DataMessageType) => Promise<void>
 
-	readonly view?: ViewType // Screen to show on Waku object
-	readonly viewParams: string[] // Other path params after the screen
 	onViewChange: (view: ViewType, ...rest: string[]) => void
 }
 
 export interface WakuObjectArgs<
+	StoreType = JSONSerializable,
+	DataMessageType = JSONSerializable,
 	ViewType extends string = string,
-> extends WakuObjectContext<ViewType>,
+> extends WakuObjectContext<StoreType, DataMessageType, ViewType>,
 		WakuObjectState {}
 
 interface WakuObjectMetadata {
@@ -64,17 +73,21 @@ interface WakuObjectMetadata {
 }
 
 interface WakuObjectDescriptor<
+	StoreType = JSONSerializable,
+	DataMessageType = JSONSerializable,
 	ViewType extends string = string,
 > extends WakuObjectMetadata {
 	onMessage?: (
 		message: DataMessage<DataMessageType>,
-		args: WakuObjectArgs<ViewType>,
+		args: WakuObjectArgs<StoreType, DataMessageType, ViewType>,
 	) => Promise<void>
 }
 
 interface WakuObjectSvelteDescriptor<
+	StoreType = JSONSerializable,
+	DataMessageType = JSONSerializable,
 	ViewType extends string = string,
-> extends WakuObjectDescriptor<ViewType> {
+> extends WakuObjectDescriptor<StoreType, DataMessageType, ViewType> {
 	readonly wakuObject: ComponentType
 	readonly standalone?: ComponentType
 }

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -3,7 +3,6 @@ import type { DataMessage } from '$lib/stores/chat'
 import type { ComponentType } from 'svelte'
 import type { Transaction, User, TransactionState } from './schemas'
 import type { Contract, Interface } from 'ethers'
-import type { CustomArgs } from ''
 
 export interface WakuObjectAdapter {
 	getTransaction(txHash: string): Promise<Transaction | undefined>
@@ -34,12 +33,15 @@ export interface WakuObjectState {
 	readonly chatName: string
 }
 
-export interface WakuObjectContext<
-	StoreType extends JSONSerializable = JSONSerializable,
-	DataMessageType extends JSONSerializable = JSONSerializable,
-	ViewType extends string = string,
-> extends WakuObjectAdapter {
+type StoreType = JSONSerializable
+type DataMessageType = JSONSerializable
+
+export interface WakuObjectContextProps<ViewType extends string = string> {
 	readonly store?: StoreType
+	readonly view?: ViewType
+}
+
+export interface WakuObjectContext<ViewType extends string = string> extends WakuObjectContextProps<ViewType>, WakuObjectAdapter {
 	updateStore: (updater: (state?: StoreType) => StoreType) => void
 
 	send: (data: DataMessageType) => Promise<void>
@@ -50,10 +52,8 @@ export interface WakuObjectContext<
 }
 
 export interface WakuObjectArgs<
-	StoreType extends JSONSerializable = JSONSerializable,
-	DataMessageType extends JSONSerializable = JSONSerializable,
 	ViewType extends string = string,
-> extends WakuObjectContext<StoreType, DataMessageType, ViewType>,
+> extends WakuObjectContext<ViewType>,
 		WakuObjectState {}
 
 interface WakuObjectMetadata {
@@ -64,26 +64,17 @@ interface WakuObjectMetadata {
 }
 
 interface WakuObjectDescriptor<
-	StoreType extends JSONSerializable = JSONSerializable,
-	DataMessageType extends JSONSerializable = JSONSerializable,
 	ViewType extends string = string,
 > extends WakuObjectMetadata {
 	onMessage?: (
 		message: DataMessage<DataMessageType>,
-		args: WakuObjectArgs<StoreType, DataMessageType, ViewType>,
+		args: WakuObjectArgs<ViewType>,
 	) => Promise<void>
 }
 
-export type CustomArgs = {
-	name: string
-}
-
 interface WakuObjectSvelteDescriptor<
-	StoreType extends JSONSerializable = JSONSerializable,
-	DataMessageType extends JSONSerializable = JSONSerializable,
 	ViewType extends string = string,
-> extends WakuObjectDescriptor<StoreType, DataMessageType, ViewType> {
+> extends WakuObjectDescriptor<ViewType> {
 	readonly wakuObject: ComponentType
 	readonly standalone?: ComponentType
-	readonly customArgs?: CustomArgs
 }

--- a/src/lib/objects/payggy/standalone.svelte
+++ b/src/lib/objects/payggy/standalone.svelte
@@ -8,6 +8,7 @@
 	import ChooseAmount from './views/choose-amount.svelte'
 	import ConfirmSend from './views/confirm-send.svelte'
 	import SelectUser from './views/select-user.svelte'
+	import { isGroupChatId } from '$lib/stores/chat'
 
 	export let args: WakuObjectArgs
 
@@ -27,7 +28,7 @@
 	let amount = ''
 	let toUser: User | undefined = undefined
 
-	$: isGroupchat = args.users.length !== 2
+	$: isGroupchat = isGroupChatId(args.chatId)
 
 	// If this is private chat, set the user to which we want to send funds to the other user
 	$: if (!isGroupchat && !args.view)

--- a/src/routes/chat/[id]/object/new/+page.svelte
+++ b/src/routes/chat/[id]/object/new/+page.svelte
@@ -24,7 +24,7 @@
 		...object,
 		onClick: object.standalone
 			? () => {
-					goto(ROUTES.OBJECT($page.params.id, object.objectId, 'new'))
+					goto(ROUTES.OBJECT($page.params.id, encodeURIComponent(object.objectId), 'new'))
 			  }
 			: () => {
 					createObject(object.objectId, {


### PR DESCRIPTION
This is the host side of this [PR](https://github.com/logos-innovation-lab/waku-objects/pull/21). First that PR needs to be reviewed, merged and published to npmjs so that this one can use it as a dependency. Until that this will be broken.

- Added support for reactive `args`, so that when they change in the host application (e.g. when there is a new user added to a group chat) then a message is sent to the external object to update the arguments and possibly re-render. There is some optimization so that the hash of the serialized `args` is stored on the host side, and an update is only sent if that changes.
- There is also a new message called `init` that the object sends to the host app when the object initialization is complete, so that the host app can send the updated `args` (which is the `context` + `state`). Without this the initialization is full with race-conditions and it is not sure when the object is initialized.
- There is initial support for standalone components, that is when the object is not a chat widget, but it is used when the object needs some initial parameters to be set up or displaying the details of the object. Currently a flag needs to be set in the `getExternalDescriptor`, this could ultimately come from the metadata of the object or alternatively objects could have different targets for chat widget and standalone components. The current implementation sets the `class` of the div with `id=app` to `chat` or `standalone` depending on what the host app displays. This is bit hacky, but it demonstrates that this is possible and later can be improved. I added a more detailed descriptions to the caveats section about the issues with the current implementation.

Known issues:
- [x] Regarding the standalone components, I just realized that currently they render to the whole screen. I think it would be better if the header would be rendered by the host application, so that they can be always closed, and if needed navigation backwards would be allowed. I checked the design and for the implemented components there needs to be no change to achieve this. (https://github.com/logos-innovation-lab/waku-objects-playground/issues/368)
- [x] As mentioned above the standalone component currently uses the same JS code to render itself as the chat widget. It can differentiate between the states based on the `class` property of the top-level app `div`. This feels a bit sketchy, and discussing other alternatives would be appreciated. One idea I thought about but ultimately discarded was to inject the state in some variable with Javascript, but after #358 it seems to be better to use less Javascript than more of it. (https://github.com/logos-innovation-lab/waku-objects-playground/issues/369)
- [x] The iframe styling uses the default style, so it does not look like the app at all. I found some [ideas](https://stackoverflow.com/questions/4612374/iframe-inherit-from-parent) how you can copy the style between iframes, but I don't know how well it would work with the [luminance](https://www.npmjs.com/package/@waku-objects/luminance) design system, so that requires further research. (https://github.com/logos-innovation-lab/waku-objects-playground/issues/370)
- [x] The size of the iframe is now set based on the content of the iframe instead of the [default iframe size](https://stackoverflow.com/questions/5871668/default-width-height-of-an-iframe). For the chat widget the width should depend on the rest of the UI, because the chat widget width is a function of that (8/12 if I remember correctly). For standalone components it should fill the whole screen (minus the header). (https://github.com/logos-innovation-lab/waku-objects-playground/issues/370)
- [x] Currently all `DataMessage`s sent between the objects result in a rendered component. However there were discussions where sometimes there could be better UX if the `DataMessage` would not display a new bubble, but change the state of an existing one. With the current implementation there is no way to do it, and it would be great to cover this. For example the `WakuObjectDescriptor` could have a function that returns a `boolean` based on the message and the current state if the message needs to be displayed or not, or the `onMessage` could return a `boolean`. This is getting more interesting with the external object  because here we need to decide if we want to display a chat bubble or not before the iframe is displayed and logic runs in that. (https://github.com/logos-innovation-lab/waku-objects-playground/issues/371)