### PR TITLE
feat: waku improvements

### DIFF
--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -37,6 +37,7 @@ function getTopic(contentTopic: ContentTopic, id: string | '' = '') {
 
 interface ConnectWakuOptions {
 	onDisconnect?: () => void
+	onConnect?: (connections: unknown[]) => void
 }
 
 export async function connectWaku(options?: ConnectWakuOptions) {
@@ -45,6 +46,13 @@ export async function connectWaku(options?: ConnectWakuOptions) {
 	waku.libp2p.addEventListener('peer:disconnect', () => {
 		if (options?.onDisconnect && waku.libp2p.getConnections().length === 0) {
 			options.onDisconnect()
+		}
+	})
+
+	waku.libp2p.addEventListener('peer:connect', () => {
+		if (options?.onConnect && waku.libp2p.getConnections().length > 0) {
+			const connections = waku.libp2p.getConnections()
+			options.onConnect(connections)
 		}
 	})
 
@@ -107,7 +115,5 @@ export async function sendMessage(waku: LightNode, id: string, message: unknown)
 	const encoder = createEncoder({ contentTopic })
 
 	const { error } = await waku.lightPush.send(encoder, { payload })
-	if (error) {
-		console.error(error)
-	}
+	return error
 }


### PR DESCRIPTION
This PR contains multiple improvements that I found during testing with the bots:

- Limit the number of messages in a chat to 100 (can be changed arbitrarily. This is needed because if the chat grows too long then the browser won't be able to load it and will use too much memory. Obviously this comes with old messages to be forgotten, maybe this could be added as an extra feature with a button to load historical messages on a per-demand basis.
- Logs the console with debug loglevel if the waku is connected or not. This gives a nice visual feedback that helps evaluating intuitively the quality of the connection. Currently I see a disconnect in every 30 seconds (see this [issue](https://github.com/waku-org/js-waku/issues/1565) about it)
- Insert the timestamp to subscribed messages too, instead of just filtered queried ones.  This may potentially eliminate duplicated messages.