### PR TITLE
feat: mentions

### DIFF
--- a/src/lib/utils/text.test.ts
+++ b/src/lib/utils/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { replaceUrlToLink } from './text'
+import { replaceAtMention, replaceUrlToLink } from './text'
 
 describe('replaceUrlToLink', () => {
 	const values = [
@@ -27,6 +27,33 @@ describe('replaceUrlToLink', () => {
 	values.forEach(({ text, expected }) => {
 		it(`with text ${text} should return ${expected}`, () => {
 			expect(replaceUrlToLink(text)).toStrictEqual(expected)
+		})
+	})
+})
+
+describe('replaceAtMention', () => {
+	const values = [
+		{
+			text: '@abc',
+			expected: '<b>@abc</b>',
+		},
+		{
+			text: '@abc ',
+			expected: '<b>@abc</b> ',
+		},
+		{
+			text: '@abc hello',
+			expected: '<b>@abc</b> hello',
+		},
+		{
+			text: '@abc hello @abc',
+			expected: '<b>@abc</b> hello <b>@abc</b>',
+		},
+	]
+
+	values.forEach(({ text, expected }) => {
+		it(`with text ${text} should return ${expected}`, () => {
+			expect(replaceAtMention(text)).toStrictEqual(expected)
 		})
 	})
 })

--- a/src/lib/utils/text.ts
+++ b/src/lib/utils/text.ts
@@ -7,10 +7,14 @@ export function replaceUrlToLink(text: string) {
 	})
 }
 
+export function replaceAtMention(text: string) {
+	return text.replaceAll(/(@\w+)([^\w]|$)/g, '<b>$1</b>$2')
+}
+
 function replaceNewlineToLineBreak(text: string) {
 	return text.replaceAll('\n', '</br>')
 }
 
 export function textToHTML(text: string) {
-	return replaceUrlToLink(replaceNewlineToLineBreak(text))
+	return replaceUrlToLink(replaceNewlineToLineBreak(replaceAtMention(text)))
 }

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -135,6 +135,10 @@ a {
 	text-decoration: underline;
 }
 
+b {
+	font-weight: bold;
+}
+
 .text-title {
 	font-weight: var(--font-weight-700);
 	font-size: var(--font-size-lg);


### PR DESCRIPTION
This PR adds @mentions to group chats. It consists of several parts:
- Replaces the `@name` in the original text to `@address` in the actual text message before sending. This way if the users change their display name the mention will be still relevant.
- It replaces back to `@name` from `@address` before the message is displayed
- Any `@mention` will be replaced by **bold** text before the message is displayed.