### PR TITLE
feat: remove add images or object dropdown

### DIFF
--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -11,8 +11,6 @@
 	import Textarea from '$lib/components/textarea.svelte'
 	import Button from '$lib/components/button.svelte'
 	import Avatar from '$lib/components/avatar.svelte'
-	import Dropdown from '$lib/components/dropdown.svelte'
-	import DropdownItem from '$lib/components/dropdown-item.svelte'
 	import WakuObject from '$lib/objects/chat.svelte'
 
 	import { goto } from '$app/navigation'
@@ -114,21 +112,9 @@
 				<div class="chat-input-wrapper">
 					<Container>
 						<div class="chat-input">
-							<Dropdown up left>
-								<!-- TODO: make button "active" while dropdown is open -->
-								<Button variant="icon" slot="button">
-									<Add />
-								</Button>
-								<DropdownItem disabled onClick={() => console.log('Pic from Cam')}
-									>Pic from Cam</DropdownItem
-								>
-								<DropdownItem disabled onClick={() => console.log('Pic from Lib')}
-									>Pic from Lib</DropdownItem
-								>
-								<DropdownItem onClick={() => goto(ROUTES.OBJECTS($page.params.id))}
-									>Waku Object</DropdownItem
-								>
-							</Dropdown>
+							<Button variant="icon" on:click={() => goto(ROUTES.OBJECTS($page.params.id))}>
+								<Add />
+							</Button>
 							<Textarea
 								placeholder="Message"
 								autofocus

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -12,8 +12,6 @@
 	import Textarea from '$lib/components/textarea.svelte'
 	import Button from '$lib/components/button.svelte'
 	import Avatar from '$lib/components/avatar.svelte'
-	import Dropdown from '$lib/components/dropdown.svelte'
-	import DropdownItem from '$lib/components/dropdown-item.svelte'
 	import WakuObject from '$lib/objects/chat.svelte'
 
 	import { goto } from '$app/navigation'
@@ -221,21 +219,9 @@
 				<div class="chat-input-wrapper">
 					<Container>
 						<div class="chat-input">
-							<Dropdown up left>
-								<!-- TODO: make button "active" while dropdown is open -->
-								<Button variant="icon" slot="button">
-									<Add />
-								</Button>
-								<DropdownItem disabled onClick={() => console.log('Pic from Cam')}
-									>Pic from Cam</DropdownItem
-								>
-								<DropdownItem disabled onClick={() => console.log('Pic from Lib')}
-									>Pic from Lib</DropdownItem
-								>
-								<DropdownItem onClick={() => goto(ROUTES.OBJECTS($page.params.id))}
-									>Waku Object</DropdownItem
-								>
-							</Dropdown>
+							<Button variant="icon" on:click={() => goto(ROUTES.OBJECTS($page.params.id))}>
+								<Add />
+							</Button>
 							<Textarea
 								placeholder="Message"
 								bind:value={text}


### PR DESCRIPTION
This removes the add object/image dropdown. Instead, clicking the + button takes you directly to new object. In the last mile document we agreed that instead of uploading pictures we might implement galery waku object.

![Screenshot 2023-09-14 at 12 01 08](https://github.com/logos-innovation-lab/waku-objects-playground/assets/7974813/0e743188-d4d6-41aa-9484-649dbda78114)
