### PR TITLE
feat: safe waku

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -6,13 +6,11 @@ import {
 	type Message,
 	isGroupChatId,
 	type DataMessage,
-	getLastMessageTime,
 	getLastSeenMessageTime,
 	type ChatData,
 } from '$lib/stores/chat'
 import type { User } from '$lib/types'
-import { PageDirection, type LightNode, type TimeFilter } from '@waku/interfaces'
-import { connectWaku, sendMessage } from './waku'
+import type { TimeFilter } from '@waku/interfaces'
 import type { BaseWallet, Wallet } from 'ethers'
 import { get } from 'svelte/store'
 import { objectStore, objectKey } from '$lib/stores/objects'
@@ -32,15 +30,9 @@ import { makeWakustore } from './wakustore'
 import type { StorageChat, StorageChatEntry, StorageObjectEntry, StorageProfile } from './types'
 import { genRandomHex } from '$lib/utils'
 import { walletStore } from '$lib/stores/wallet'
+import { SafeWaku } from './safe-waku'
 
 const MAX_MESSAGES = 100
-
-interface QueuedMessage {
-	message: Message
-	address: string
-	id: string
-	adapter: WakuObjectAdapter
-}
 
 function createPrivateChat(chatId: string, user: User, ownAddress: string): string {
 	const ownProfile = get(profile)
@@ -158,27 +150,16 @@ async function executeOnDataMessage(
 }
 
 export default class WakuAdapter implements Adapter {
-	private waku: LightNode | undefined
+	private safeWaku = new SafeWaku()
 	private subscriptions: Array<() => void> = []
 	private numWaitingSaveChats = 0
 	private isSavingChats = false
-	private queuedMessages: QueuedMessage[] = []
-	private isHandlingMessage = false
 
 	async onLogIn(wallet: BaseWallet): Promise<void> {
 		const address = wallet.address
-		this.waku = await connectWaku({
-			onDisconnect: () => {
-				console.debug('❌ disconnected from waku')
-			},
-			onConnect: () => {
-				console.debug('✅ connected to waku')
-			},
-		})
 
+		const ws = await this.makeWakustore()
 		const wakuObjectAdapter = makeWakuObjectAdapter(this, wallet)
-
-		const ws = makeWakustore(this.waku)
 
 		const storageProfile = await ws.getDoc<StorageProfile>('profile', address)
 		profile.update((state) => ({ ...state, ...storageProfile, address, loading: false }))
@@ -186,8 +167,8 @@ export default class WakuAdapter implements Adapter {
 		const storageChatEntries = await ws.getDoc<StorageChatEntry[]>('chats', address)
 		chats.update((state) => ({ ...state, chats: new Map(storageChatEntries), loading: false }))
 
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
-		const adapter = this
+		console.debug({ storageChatEntries })
+
 		const allChats = Array.from(get(chats).chats)
 
 		// private chats
@@ -205,7 +186,13 @@ export default class WakuAdapter implements Adapter {
 		const groupChatIds = allChats.filter(([id]) => isGroupChatId(id)).map(([id]) => id)
 
 		for (const groupChatId of groupChatIds) {
-			await this.subscribeToGroupChat(groupChatId, address, wakuObjectAdapter)
+			const lastSeenMessageTime = getLastSeenMessageTime(privateChats)
+			const now = new Date()
+			const timeFilter = {
+				startTime: new Date(lastSeenMessageTime + 1),
+				endTime: now,
+			}
+			await this.subscribeToGroupChat(groupChatId, address, wakuObjectAdapter, timeFilter)
 		}
 
 		// chat store
@@ -236,9 +223,6 @@ export default class WakuAdapter implements Adapter {
 		}))
 
 		const subscribeObjectStore = objectStore.subscribe(async (objects) => {
-			if (!adapter.waku) {
-				return
-			}
 			await ws.setDoc<StorageObjectEntry[]>('objects', address, Array.from(objects.objects))
 		})
 		this.subscriptions.push(subscribeObjectStore)
@@ -249,16 +233,13 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	async onLogOut() {
+		await this.safeWaku.unsubscribeAll()
 		this.subscriptions.forEach((s) => s())
 		this.subscriptions = []
 		profile.set({ loading: false })
 	}
 
 	async saveUserProfile(address: string, name?: string, avatar?: string): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
 		const defaultProfile: StorageProfile = { name: name ?? address }
 		const storageProfile = (await this.fetchStorageProfile(address)) || defaultProfile
 
@@ -266,24 +247,17 @@ export default class WakuAdapter implements Adapter {
 		if (name) storageProfile.name = name
 
 		if (avatar || name) {
-			const ws = makeWakustore(this.waku)
+			const ws = await this.makeWakustore()
 			ws.setDoc<StorageProfile>('profile', address, storageProfile)
 			profile.update((state) => ({ ...state, address, name, avatar }))
 		}
 	}
 
 	async getUserProfile(address: string): Promise<User | undefined> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
 		return this.storageProfileToUser(address)
 	}
 
 	async startChat(address: string, peerAddress: string): Promise<string> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
 		const chatId = peerAddress
 		const user = await this.storageProfileToUser(chatId)
 		if (!user) {
@@ -301,9 +275,6 @@ export default class WakuAdapter implements Adapter {
 		name: string,
 		avatar?: string,
 	): Promise<string> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
 		if (memberAddresses.length === 0) {
 			throw 'invalid chat'
 		}
@@ -321,7 +292,7 @@ export default class WakuAdapter implements Adapter {
 
 		createGroupChat(chatId, chat.users, name, avatar, true)
 
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 		await ws.setDoc<StorageChat>('group-chats', chatId, storageChat)
 		await this.subscribeToGroupChat(chatId, wallet.address, wakuObjectAdapter)
 
@@ -329,11 +300,7 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	async addMemberToGroupChat(chatId: string, users: string[]): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 
 		const groupChat = await ws.getDoc<StorageChat>('group-chats', chatId)
 		if (!groupChat) {
@@ -348,11 +315,7 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	async removeFromGroupChat(chatId: string, address: string): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 
 		const groupChat = await ws.getDoc<StorageChat>('group-chats', chatId)
 		if (!groupChat) {
@@ -367,11 +330,7 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	async saveGroupChatProfile(chatId: string, name?: string, avatar?: string): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 
 		const groupChat = await ws.getDoc<StorageChat>('group-chats', chatId)
 		if (!groupChat) {
@@ -387,10 +346,6 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	async sendChatMessage(wallet: BaseWallet, chatId: string, text: string): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
 		const fromAddress = wallet.address
 		const message: Message = {
 			type: 'user',
@@ -402,7 +357,7 @@ export default class WakuAdapter implements Adapter {
 		const wakuObjectAdapter = makeWakuObjectAdapter(this, wallet)
 
 		await addMessageToChat(fromAddress, wakuObjectAdapter, chatId, message)
-		await sendMessage(this.waku, chatId, message)
+		await this.safeWaku.sendMessage(chatId, message)
 	}
 
 	async sendData(
@@ -412,10 +367,6 @@ export default class WakuAdapter implements Adapter {
 		instanceId: string,
 		data: JSONSerializable,
 	): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
 		const fromAddress = wallet.address
 		const message: Message = {
 			type: 'data',
@@ -430,14 +381,10 @@ export default class WakuAdapter implements Adapter {
 		const send = (data: JSONValue) => this.sendData(wallet, chatId, objectId, instanceId, data)
 
 		await addMessageToChat(fromAddress, wakuObjectAdapter, chatId, message, send)
-		await sendMessage(this.waku, chatId, message)
+		await this.safeWaku.sendMessage(chatId, message)
 	}
 
 	async sendInvite(wallet: BaseWallet, chatId: string, users: string[]): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
 		if (!isGroupChatId(chatId)) {
 			throw 'chat id is private'
 		}
@@ -451,7 +398,7 @@ export default class WakuAdapter implements Adapter {
 		}
 
 		for (const user of users) {
-			await sendMessage(this.waku, user, message)
+			await this.safeWaku.sendMessage(user, message)
 		}
 	}
 
@@ -462,10 +409,6 @@ export default class WakuAdapter implements Adapter {
 		instanceId: string,
 		updater: (state: JSONSerializable) => JSONSerializable,
 	): Promise<void> {
-		if (!this.waku) {
-			this.waku = await connectWaku()
-		}
-
 		const key = objectKey(objectId, instanceId)
 		const wakuObjectStore = get(objectStore)
 
@@ -492,11 +435,12 @@ export default class WakuAdapter implements Adapter {
 		}
 	}
 
-	private async storageChatToChat(chatId: string, storageChat: StorageChat): Promise<Chat> {
-		if (!this.waku) {
-			throw 'no waku'
-		}
+	private async makeWakustore() {
+		const waku = await this.safeWaku.connect()
+		return makeWakustore(waku)
+	}
 
+	private async storageChatToChat(chatId: string, storageChat: StorageChat): Promise<Chat> {
 		const userPromises = storageChat.users.map((user) => this.storageProfileToUser(user))
 		const allUsers = await Promise.all(userPromises)
 		const users = allUsers.filter((user) => user) as User[]
@@ -513,11 +457,7 @@ export default class WakuAdapter implements Adapter {
 
 	// fetches the profile from the network
 	private async fetchStorageProfile(address: string): Promise<StorageProfile | undefined> {
-		if (!this.waku) {
-			throw 'no waku'
-		}
-
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 		const storageProfile = await ws.getDoc<StorageProfile>('profile', address)
 
 		return storageProfile
@@ -554,11 +494,7 @@ export default class WakuAdapter implements Adapter {
 		wakuObjectAdapter: WakuObjectAdapter,
 		timeFilter?: TimeFilter,
 	) {
-		if (!this.waku) {
-			return
-		}
-
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 
 		const groupChatSubscription = await ws.onSnapshot<StorageChat>(
 			ws.docQuery('group-chats', groupChatId),
@@ -588,60 +524,9 @@ export default class WakuAdapter implements Adapter {
 		wakuObjectAdapter: WakuObjectAdapter,
 		timeFilter?: TimeFilter,
 	) {
-		if (!this.waku) {
-			return
-		}
-
-		const ws = makeWakustore(this.waku)
-
-		const startTime = new Date(getLastMessageTime(get(chats).chats.get(id)) + 1)
-		const endTime = new Date()
-
-		const subscription = await ws.onSnapshot<Message>(
-			ws.collectionQuery('private-message', id, {
-				timeFilter: timeFilter || { startTime, endTime },
-				pageDirection: PageDirection.BACKWARD,
-				pageSize: 1000,
-			}),
-			(message) => {
-				this.queueMessage(message, address, id, wakuObjectAdapter)
-			},
+		this.safeWaku.subscribe(id, timeFilter, (message, chatId) =>
+			this.handleMessage(message, address, chatId, wakuObjectAdapter),
 		)
-		this.subscriptions.push(subscription)
-	}
-
-	private async queueMessage(
-		message: Message,
-		address: string,
-		id: string,
-		adapter: WakuObjectAdapter,
-	) {
-		this.queuedMessages.push({
-			message,
-			address,
-			id,
-			adapter,
-		})
-
-		if (this.isHandlingMessage) {
-			return
-		}
-
-		this.isHandlingMessage = true
-
-		while (this.queuedMessages.length > 0) {
-			const queuedMessage = this.queuedMessages.shift()
-			if (queuedMessage) {
-				await this.handleMessage(
-					queuedMessage.message,
-					queuedMessage.address,
-					queuedMessage.id,
-					queuedMessage.adapter,
-				)
-			}
-		}
-
-		this.isHandlingMessage = false
 	}
 
 	private async handleMessage(
@@ -752,11 +637,7 @@ export default class WakuAdapter implements Adapter {
 	}
 
 	private async saveChatStore(address: string) {
-		if (!this.waku) {
-			return
-		}
-
-		const ws = makeWakustore(this.waku)
+		const ws = await this.makeWakustore()
 		const chatData: ChatData = get(chats)
 
 		const result = await ws.setDoc<StorageChatEntry[]>('chats', address, Array.from(chatData.chats))

--- a/src/lib/adapters/waku/safe-waku.ts
+++ b/src/lib/adapters/waku/safe-waku.ts
@@ -1,0 +1,232 @@
+import { connectWaku, type ConnectWakuOptions, sendMessage } from '$lib/adapters/waku/waku'
+import { isGroupChatId, type Message } from '$lib/stores/chat'
+import type { LightNode, TimeFilter, Unsubscribe } from '@waku/interfaces'
+import { PageDirection } from '@waku/interfaces'
+import { makeWakustore } from './wakustore'
+
+type Callback = (message: Message, chatId: string) => Promise<void>
+
+interface QueuedMessage {
+	chatMessage: Message
+	chatId: string
+	callback: Callback
+}
+
+interface Subscription {
+	unsubscribe: Unsubscribe
+	callback: Callback
+}
+
+export class SafeWaku {
+	public lightNode: LightNode | undefined = undefined
+	private subscriptions = new Map<string, Subscription>()
+	private lastMessages = new Map<string, Message>()
+	private lastSentTimestamp = 0
+	private isSubscribing = false
+	public readonly errors = {
+		numDisconnect: 0,
+		numSendError: 0,
+	}
+	private queuedMessages: QueuedMessage[] = []
+	private isHandlingMessage = false
+
+	constructor(public readonly options?: ConnectWakuOptions) {}
+
+	async connect() {
+		if (this.lightNode) {
+			return this.lightNode
+		}
+
+		this.lightNode = await this.connectWaku()
+		return this.lightNode
+	}
+
+	async subscribe(
+		chatId: string,
+		timeFilter: TimeFilter | undefined,
+		callback: (message: Message, chatId: string) => Promise<void>,
+	) {
+		if (!this.lightNode) {
+			this.lightNode = await this.connectWaku()
+		}
+
+		const lastMessageTime = this.lastMessages.get(chatId)?.timestamp || 0
+		const startTime = new Date(lastMessageTime + 1)
+		const endTime = new Date()
+		const calculatedTimeFilter = lastMessageTime
+			? { startTime, endTime }
+			: { startTime: endTime, endTime }
+		timeFilter = timeFilter || calculatedTimeFilter
+
+		const talkEmoji = isGroupChatId(chatId) ? '🗫' : '🗩'
+		console.debug(`${talkEmoji}  subscribe to ${chatId}`)
+
+		const ws = makeWakustore(this.lightNode)
+		const unsubscribe = await ws.onSnapshot<Message>(
+			ws.collectionQuery('private-message', chatId, {
+				timeFilter,
+				pageDirection: PageDirection.BACKWARD,
+				pageSize: 1000,
+			}),
+			(message) => this.queueMessage(callback, message, chatId),
+		)
+
+		const subscription = {
+			unsubscribe,
+			callback,
+		}
+
+		this.subscriptions.set(chatId, subscription)
+	}
+
+	async unsubscribeAll() {
+		for (const subscription of this.subscriptions.values()) {
+			await subscription.unsubscribe()
+		}
+
+		this.subscriptions = new Map()
+	}
+
+	async sendMessage(id: string, message: Message) {
+		if (!this.lightNode) {
+			this.lightNode = await connectWaku(this.options)
+		}
+
+		let error = undefined
+		let timeout = 1_000
+
+		const start = Date.now()
+
+		if (message.timestamp === this.lastSentTimestamp) {
+			message.timestamp++
+		}
+		this.lastSentTimestamp = message.timestamp
+
+		do {
+			try {
+				error = await sendMessage(this.lightNode, id, message)
+			} catch (e) {
+				error = e
+			} finally {
+				if (error) {
+					this.errors.numSendError++
+					console.debug(`⁉️  Error: ${error}`)
+					console.debug(`🕓 Waiting ${timeout} milliseconds...`)
+					await new Promise((r) => setTimeout(r, timeout))
+					if (timeout < 120_000) {
+						timeout += timeout
+					}
+				}
+			}
+		} while (error)
+
+		const elapsed = Date.now() - start
+
+		console.debug({ message, id })
+
+		if (elapsed > 1000) {
+			console.debug(`⏰ sending message took ${elapsed} milliseconds`)
+		}
+	}
+
+	private connectWaku() {
+		console.debug('connectWaku')
+
+		const waku = connectWaku({
+			onConnect: (connections) => {
+				console.debug('✅ connected to waku', { connections })
+				this.safeResubscribe()
+
+				if (this.options?.onConnect) {
+					this.options?.onConnect(connections)
+				}
+			},
+			onDisconnect: () => {
+				console.debug('❌ disconnected from waku')
+				this.errors.numDisconnect++
+
+				if (this.options?.onDisconnect) {
+					this.options.onDisconnect()
+				}
+			},
+		})
+		return waku
+	}
+
+	private async safeResubscribe() {
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			try {
+				return await this.resubscribe()
+			} catch (e) {
+				console.error(`⁉️  ${e}`)
+			}
+		}
+	}
+
+	private async resubscribe() {
+		if (!this.lightNode) {
+			return
+		}
+
+		if (this.isSubscribing) {
+			return
+		}
+
+		this.isSubscribing = true
+
+		const chatIds = this.subscriptions.keys()
+		for (const subscription of this.subscriptions.values()) {
+			await subscription.unsubscribe()
+		}
+
+		const oldSubscriptions = this.subscriptions
+		this.subscriptions = new Map()
+
+		for (const chatId of chatIds) {
+			const callback = oldSubscriptions.get(chatId)?.callback
+			if (callback) {
+				await this.subscribe(chatId, undefined, callback)
+			}
+		}
+
+		this.isSubscribing = false
+	}
+
+	private async queueMessage(callback: Callback, chatMessage: Message, chatId: string) {
+		this.queuedMessages.push({
+			callback,
+			chatMessage,
+			chatId,
+		})
+
+		if (this.isHandlingMessage) {
+			return
+		}
+
+		this.isHandlingMessage = true
+
+		while (this.queuedMessages.length > 0) {
+			const queuedMessage = this.queuedMessages.shift()
+			if (queuedMessage) {
+				// deduplicate already seen messages
+				const lastMessage = this.lastMessages.get(chatId)
+				if (
+					lastMessage &&
+					lastMessage.timestamp === chatMessage.timestamp &&
+					lastMessage.type === chatMessage.type &&
+					lastMessage.fromAddress === chatMessage.fromAddress
+				) {
+					console.debug('🙈 ignoring duplicate message', { chatMessage })
+					continue
+				}
+
+				this.lastMessages.set(chatId, chatMessage)
+
+				await callback(queuedMessage.chatMessage, queuedMessage.chatId)
+			}
+		}
+
+		this.isHandlingMessage = false
+	}
+}

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -35,7 +35,7 @@ function getTopic(contentTopic: ContentTopic, id: string | '' = '') {
 	return `/${topicApp}/${topicVersion}/${contentTopic}/${id}`
 }
 
-interface ConnectWakuOptions {
+export interface ConnectWakuOptions {
 	onDisconnect?: () => void
 	onConnect?: (connections: unknown[]) => void
 }
@@ -86,10 +86,9 @@ export async function storeDocument(
 	const json = JSON.stringify(document)
 	const payload = utf8ToBytes(json)
 
-	const { error } = await waku.lightPush.send(encoder, { payload })
-	if (error) {
-		console.error(error)
-	}
+	const sendResult = await waku.lightPush.send(encoder, { payload })
+	console.debug({ sendResult, contentTopic })
+	return sendResult.error
 }
 
 export async function readStore(
@@ -114,6 +113,7 @@ export async function sendMessage(waku: LightNode, id: string, message: unknown)
 	const contentTopic = getTopic('private-message', id)
 	const encoder = createEncoder({ contentTopic })
 
-	const { error } = await waku.lightPush.send(encoder, { payload })
-	return error
+	const sendResult = await waku.lightPush.send(encoder, { payload })
+	console.debug({ sendResult, contentTopic })
+	return sendResult.error
 }

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -16,13 +16,17 @@ import {
 	type Unsubscribe,
 } from '@waku/interfaces'
 
-const peerMultiaddr = multiaddr(
+const peers = [
+	// use this address for local testing
+	// '/ip4/127.0.0.1/tcp/8000/ws/p2p/16Uiu2HAm53sojJN72rFbYg6GV2LpRRER9XeWkiEAhjKy3aL9cN5Z',
+
 	// '/dns4/ws.waku.apyos.dev/tcp/443/wss/p2p/16Uiu2HAm5wH4dPAV6zDfrBHkWt9Wu9iiXT4ehHdUArDUbEevzmBY',
 	'/dns4/ws.waku-1.apyos.dev/tcp/443/wss/p2p/16Uiu2HAm8gXHntr3SB5sde11pavjptaoiqyvwoX3GyEZWKMPiuBu',
 
-	// use this address for local testing
-	// '/ip4/127.0.0.1/tcp/8000/ws/p2p/16Uiu2HAm53sojJN72rFbYg6GV2LpRRER9XeWkiEAhjKy3aL9cN5Z',
-)
+	// '/dns4/waku.gra.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmDvywnsGaB32tFqwjTsg8sfC1ZV2EXo3xjxM4V2gvH6Up',
+	// '/dns4/waku.bhs.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAkvrRkEHRMfe26F8NCWUfzMuaCfyCzwoPSUYG7yminM5Bn',
+	// '/dns4/waku.de.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmRgjA134DcoyK8r44pKWJQ69C7McLSWtRgxUVwkKAsbGx',
+]
 
 export type ContentTopic = 'private-message' | 'profile' | 'chats' | 'objects' | 'group-chats'
 
@@ -57,7 +61,10 @@ export async function connectWaku(options?: ConnectWakuOptions) {
 	})
 
 	await waku.start()
-	await waku.dial(peerMultiaddr)
+	for (const peer of peers) {
+		const addr = multiaddr(peer)
+		await waku.dial(addr)
+	}
 	await waitForRemotePeer(waku, [Protocols.Filter, Protocols.LightPush, Protocols.Store])
 
 	return waku
@@ -87,7 +94,6 @@ export async function storeDocument(
 	const payload = utf8ToBytes(json)
 
 	const sendResult = await waku.lightPush.send(encoder, { payload })
-	console.debug({ sendResult, contentTopic })
 	return sendResult.error
 }
 
@@ -114,6 +120,5 @@ export async function sendMessage(waku: LightNode, id: string, message: unknown)
 	const encoder = createEncoder({ contentTopic })
 
 	const sendResult = await waku.lightPush.send(encoder, { payload })
-	console.debug({ sendResult, contentTopic })
 	return sendResult.error
 }

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -104,7 +104,8 @@ function createChatStore(): ChatStore {
 					return state
 				}
 				const newMap = new Map(state.chats)
-				newMap.set(chatId, update(oldChat))
+				const newChat = update(oldChat)
+				newMap.set(chatId, newChat)
 
 				return {
 					...state,

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -55,14 +55,14 @@
 	})
 
 	$: messages = $chats.chats.get($page.params.id)?.messages || []
-	let loading = false
+	let isSending = false
 	let text = ''
 
 	const sendMessage = async (wallet: HDNodeWallet) => {
-		loading = true
+		isSending = true
 		await adapters.sendChatMessage(wallet, $page.params.id, text)
 		text = ''
-		loading = false
+		isSending = false
 	}
 </script>
 
@@ -133,7 +133,7 @@
 								}}
 							/>
 							{#if text.length > 0}
-								<Button variant="strong" disabled={loading} on:click={() => sendMessage(wallet)}>
+								<Button variant="strong" disabled={isSending} on:click={() => sendMessage(wallet)}>
 									<ArrowUp />
 								</Button>
 							{/if}

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -65,15 +65,15 @@
 	})
 
 	$: messages = $chats.chats.get($page.params.id)?.messages || []
-	let loading = false
+	let isSending = false
 	let text = ''
 
 	const sendMessage = async (wallet: HDNodeWallet) => {
-		loading = true
+		isSending = true
 		const messageText = replaceNamesWithAddresses(text)
 		await adapters.sendChatMessage(wallet, $page.params.id, messageText)
 		text = ''
-		loading = false
+		isSending = false
 	}
 
 	$: inviter = chat?.users.find((user) => user.address === chat?.inviter)
@@ -224,6 +224,7 @@
 							</Button>
 							<Textarea
 								placeholder="Message"
+								autofocus
 								bind:value={text}
 								on:keypress={(e) => {
 									// When enter is pressed without modifier keys, send the message
@@ -239,7 +240,7 @@
 								}}
 							/>
 							{#if text.length > 0}
-								<Button variant="strong" disabled={loading} on:click={() => sendMessage(wallet)}>
+								<Button variant="strong" disabled={isSending} on:click={() => sendMessage(wallet)}>
 									<ArrowUp />
 								</Button>
 							{/if}


### PR DESCRIPTION
This PR adds a safe wrapper around sending and receiving waku messages. Also moves queueing and retry/resync logic to the safe wrapper from the adapter. The long term goal is to abstract away the connectivity related issues from the application.

Notes:
- There are known issues with `waku-js` (such as [this](https://github.com/waku-org/js-waku/issues/1569), [this](https://github.com/waku-org/js-waku/issues/1562) and [this](https://github.com/waku-org/js-waku/issues/1562)) that makes it very difficult or impossible to handle all errors gracefully in a wrapper at the moment.
- The Svelte `Readable` `subscribe` function calls the callback function immediately, which is not needed, that's why there are the `firstChatStoreSave` and `firstObjectStoreSave` variables.
- This safe wrapper approach does not work very well with the Svelte autoreload functionality. Editing and saving unrelated code may result in having multiple connection issues running in the background. In that case a refresh helps.
- Currently the logging is turned on with debug loglevel for the wrapper. This helps building intuition about the connectivity issues and also help to see when to refresh the browser (see the previous point).
- It would be good to disable the text inputs in the chat while the message is being sent and re-enable when it is sent. Currently only the send button is disabled but it is possible to send a message by pressing `Enter`. Maybe disabling sending with `Enter` can be a solution.
- Added preliminary support for multiple peers, however it looks like that if any of the connections are not reliable then it makes the initial connection more flaky. The solution could be to only block until there is at least one peer that is connected, but at the moment it's not clear what is the best way to achieve it. That will be addressed in a separate PR. (https://github.com/logos-innovation-lab/waku-objects-playground/issues/404)
- The disconnection flow is not heavily tested and there may be issues if there are queued messages. That will be addressed in a separate PR. (https://github.com/logos-innovation-lab/waku-objects-playground/issues/405)
