### PR TITLE
fix: remove leftover

### DIFF
--- a/src/lib/components/badge.svelte
+++ b/src/lib/components/badge.svelte
@@ -16,6 +16,7 @@
 		text-transform: uppercase;
 		min-width: 22px;
 		text-align: center;
+		white-space: nowrap;
 
 		&.dark {
 			background-color: var(--color-step-50, var(--color-dark-step-10));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -191,8 +191,6 @@
 													{@html lastMessage && lastMessage.type === 'user'
 														? replaceAddressesWithNames(lastMessage.text?.substring(0, 150), chat)
 														: 'No messages yet'}
-													{chat.joined}
-													{lastMessage?.timestamp}
 												{:else}
 													{@const inviter =
 														chat.inviter ||


### PR DESCRIPTION
Remove leftover debug output from the chat list after #403.
Also added `nowrap` css to badge to avoid a screen filled with broken badges like in the picture. This improves #335 but does not solve it completely.


![Screenshot from 2023-09-19 23-33-54](https://github.com/logos-innovation-lab/waku-objects-playground/assets/230163/3f0bb756-6145-44b1-82e9-46330552ce9c)
