### PR TITLE
fix: invite flow

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -39,7 +39,12 @@ import { SafeWaku } from './safe-waku'
 
 const MAX_MESSAGES = 100
 
-function createPrivateChat(chatId: string, user: User, ownAddress: string): string {
+function createPrivateChat(
+	chatId: string,
+	user: User,
+	ownAddress: string,
+	joined?: boolean,
+): string {
 	const ownProfile = get(profile)
 	const ownUser = {
 		name: ownProfile.name,
@@ -52,6 +57,7 @@ function createPrivateChat(chatId: string, user: User, ownAddress: string): stri
 		users: [user, ownUser],
 		name: user.name ?? user.address,
 		unread: 0,
+		joined,
 	}
 	chats.createChat(chat)
 
@@ -273,7 +279,8 @@ export default class WakuAdapter implements Adapter {
 			throw 'invalid user'
 		}
 
-		createPrivateChat(chatId, user, address)
+		const joined = true
+		createPrivateChat(chatId, user, address, joined)
 
 		return chatId
 	}


### PR DESCRIPTION
The #403 join screen to private chats PR added an extra step to the invite flow when accepting the invite, which is unnecessary. This PR fixes that.