### PR TITLE
feat: improved invite flow

### DIFF
--- a/src/routes/invite/[address]/+page.svelte
+++ b/src/routes/invite/[address]/+page.svelte
@@ -16,12 +16,12 @@
 	import { goto } from '$app/navigation'
 	import routes from '$lib/routes'
 	import { page } from '$app/stores'
-	import { chats } from '$lib/stores/chat'
+	import { chats, isGroupChatId } from '$lib/stores/chat'
 	import adapters from '$lib/adapters'
 	import { Html5Qrcode } from 'html5-qrcode'
 	import Camera from '$lib/components/icons/camera.svelte'
 	import QrCodeIcon from '$lib/components/icons/qr-code.svelte'
-	import { onDestroy } from 'svelte'
+	import { onDestroy, onMount } from 'svelte'
 	import ButtonBlock from '$lib/components/button-block.svelte'
 	import ChevronRight from '$lib/components/icons/chevron-right.svelte'
 	import Layout from '$lib/components/layout.svelte'
@@ -29,12 +29,14 @@
 	import { profile } from '$lib/stores/profile'
 	import { walletStore } from '$lib/stores/wallet'
 	import Avatar from '$lib/components/avatar.svelte'
+	import type { Unsubscriber } from 'svelte/store'
 
 	// check if the chat already exists
 	$: if ($chats.chats.has($page.params.address)) {
 		goto(routes.CHAT($page.params.address))
 	}
 
+	let unsubscribe: Unsubscriber | undefined
 	let copied = false
 	let loading = false
 	function copyToClipboard() {
@@ -107,7 +109,24 @@
 		goto(routes.CHAT(chatId))
 	}
 
+	onMount(() => {
+		// make a copy of the list of chats when the screen is opened so that later we can compare
+		const oldChats = new Map($chats.chats)
+		unsubscribe = chats.subscribe((store) => {
+			console.debug({ store, oldChats })
+			store.chats.forEach((value, key) => {
+				if (!oldChats.has(key) && !isGroupChatId(value.chatId)) {
+					// found new private chat
+					goto(routes.CHAT(value.chatId))
+				}
+			})
+		})
+	})
+
 	onDestroy(() => {
+		if (unsubscribe) {
+			unsubscribe()
+		}
 		stop()
 	})
 </script>

--- a/src/routes/invite/[address]/+page.svelte
+++ b/src/routes/invite/[address]/+page.svelte
@@ -110,12 +110,12 @@
 	}
 
 	onMount(() => {
-		// make a copy of the list of chats when the screen is opened so that later we can compare
-		const oldChats = new Map($chats.chats)
+		// make a copy of the list of chatIds when the screen is opened so that later we can compare
+		const oldChatIds = new Set($chats.chats.keys())
 		unsubscribe = chats.subscribe((store) => {
-			console.debug({ store, oldChats })
+			console.debug({ store, oldChats: oldChatIds })
 			store.chats.forEach((value, key) => {
-				if (!oldChats.has(key) && !isGroupChatId(value.chatId)) {
+				if (!oldChatIds.has(key) && !isGroupChatId(value.chatId)) {
 					// found new private chat
 					goto(routes.CHAT(value.chatId))
 				}


### PR DESCRIPTION
This PR implements and closes #213 

It changes the screen when the QR code is shared and someone starts a new private chat with you. In order to start a private chat they still have to send at least one message. This may be improved in the future by using a special message type, such as the `invite` which is only used for group chats currently.