### PR TITLE
feat: chat timestamp

### DIFF
--- a/src/lib/components/chat-date-badge.svelte
+++ b/src/lib/components/chat-date-badge.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	export let text: string
+</script>
+
+<div class="time-separator">{text}</div>
+
+<style lang="scss">
+	.time-separator {
+		background-color: var(--color-step-20, var(--color-dark-step-40));
+		color: var(--color-step-50, var(--color-dark-step-20));
+		font-size: var(--font-size-sm);
+		border-radius: var(--border-radius);
+		text-align: center;
+		margin-left: auto;
+		margin-right: auto;
+		margin-top: var(--spacing-24);
+		margin-bottom: var(--spacing-24);
+		max-width: fit-content;
+		padding-left: var(--spacing-6);
+		padding-right: var(--spacing-6);
+		padding-top: var(--spacing-3);
+		padding-bottom: var(--spacing-3);
+	}
+</style>

--- a/src/lib/components/chat-message.svelte
+++ b/src/lib/components/chat-message.svelte
@@ -18,6 +18,8 @@
 	//name of the person who sent the message
 	export let senderName: undefined | string = undefined
 
+	export let timestamp: string | undefined = undefined
+
 	const isFF = () => {
 		let browserInfo = navigator.userAgent
 		return browserInfo.includes('Firefox')
@@ -32,9 +34,23 @@
 	<div class={`${bubble ? 'bubble message-content message-text text-lg' : ''}`}>
 		<slot />
 		{#if senderName}
-			<div class="author">
-				{senderName}
+			<div class="bottom">
+				<div class="author">
+					{senderName}
+				</div>
+				{#if timestamp}
+					<div class="timestamp">
+						{timestamp}
+					</div>
+				{/if}
 			</div>
+		{/if}
+		{#if myMessage || !senderName}
+			{#if timestamp}
+				<div class="timestamp">
+					{timestamp}
+				</div>
+			{/if}
 		{/if}
 	</div>
 	{#if $$slots.avatar}
@@ -76,6 +92,8 @@
 		font-style: italic;
 		margin-left: auto;
 		margin-right: 0;
+		flex-direction: row;
+		justify-content: end;
 
 		//The + combinator matches the second element only if it immediately follows the first element.
 		& + .my-message:not(.ff) .message-text {
@@ -89,6 +107,10 @@
 			.message-text {
 				border-bottom-right-radius: 0;
 			}
+		}
+
+		.timestamp {
+			text-align: end;
 		}
 	}
 
@@ -127,6 +149,10 @@
 				}
 			}
 		}
+
+		.timestamp {
+			text-align: end;
+		}
 	}
 	.author {
 		font-family: sans-serif;
@@ -135,5 +161,22 @@
 
 	.no-text .text-lg {
 		line-height: 0;
+	}
+
+	.bottom {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		flex-grow: 1;
+
+		.timestamp {
+			margin-left: var(--spacing-12);
+		}
+	}
+
+	.timestamp {
+		font-size: var(--font-size-sm);
+		color: var(--color-step-40);
+		font-style: normal;
 	}
 </style>

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -170,22 +170,16 @@ export function formatTimestampSeparator(timestamp: number, currentDate = new Da
 		0,
 	)
 
-	// a week before `today`
-	// this is used for the calculating a day, but it should not include
-	// the same day twice, hence we only count the last 6 days
 	const yesterday = new Date(today.valueOf() - 24 * 60 * 60 * 1000)
 
-	// if it is today, show only the time with a 24 hour clock
 	if (timestamp >= today.valueOf()) {
 		return 'Today'
 	}
 
-	// if it is last week, show only the day of the week
 	if (timestamp >= yesterday.valueOf()) {
 		return 'Yesterday'
 	}
 
-	// if it is older than a week, show the month and day
 	const dateFormat = new Intl.DateTimeFormat(locale, {
 		month: 'short',
 		day: 'numeric',

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -150,3 +150,75 @@ export function formatTimestamp(timestamp: number, currentDate = new Date()) {
 
 	return dateFormat.format(date)
 }
+
+export function formatTimestampSeparator(timestamp: number, currentDate = new Date()) {
+	if (timestamp <= 0) {
+		return ''
+	}
+
+	const locale = new Intl.DateTimeFormat().resolvedOptions().locale
+	const date = new Date(timestamp)
+
+	// today at 00:00
+	const today = new Date(
+		currentDate.getFullYear(),
+		currentDate.getMonth(),
+		currentDate.getDate(),
+		0,
+		0,
+		0,
+		0,
+	)
+
+	// a week before `today`
+	// this is used for the calculating a day, but it should not include
+	// the same day twice, hence we only count the last 6 days
+	const yesterday = new Date(today.valueOf() - 24 * 60 * 60 * 1000)
+
+	// if it is today, show only the time with a 24 hour clock
+	if (timestamp >= today.valueOf()) {
+		return 'Today'
+	}
+
+	// if it is last week, show only the day of the week
+	if (timestamp >= yesterday.valueOf()) {
+		return 'Yesterday'
+	}
+
+	// if it is older than a week, show the month and day
+	const dateFormat = new Intl.DateTimeFormat(locale, {
+		month: 'short',
+		day: 'numeric',
+	})
+
+	const dayFormat = new Intl.DateTimeFormat(locale, {
+		weekday: 'short',
+	})
+
+	return `${dayFormat.format(date)}, ${dateFormat.format(date)}`
+}
+
+export function areDifferentDays(timestampA: number, timestampB: number): boolean {
+	const sepA = formatTimestampSeparator(timestampA)
+	const sepB = formatTimestampSeparator(timestampB)
+	return sepA !== sepB
+}
+
+export function formatTimestampTime(timestamp: number) {
+	if (timestamp <= 0) {
+		return ''
+	}
+
+	const locale = new Intl.DateTimeFormat().resolvedOptions().locale
+	const date = new Date(timestamp)
+
+	// if it is today, show only the time with a 24 hour clock
+	const timeFormat = new Intl.DateTimeFormat(locale, {
+		hour: 'numeric',
+		minute: 'numeric',
+		hour12: false,
+	})
+	const dateTime = timeFormat.format(date)
+
+	return dateTime
+}

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -144,14 +144,14 @@
 							<div class="messages-inner">
 								<!-- Chat bubbles -->
 								{#each messages as message, i}
+									{#if i === 0 || (i > 0 && areDifferentDays(messages[i].timestamp, messages[i - 1].timestamp))}
+										<ChatDateBadge text={formatTimestampSeparator(message.timestamp)} />
+									{/if}
 									{#if message.type === 'user' && message.text?.length > 0}
 										{@const lastMessage =
 											i + 1 === messages.length ||
 											messages[i].fromAddress !== messages[i + 1]?.fromAddress ||
 											messages[i + 1]?.type !== 'user'}
-										{#if i > 0 && areDifferentDays(messages[i].timestamp, messages[i - 1].timestamp)}
-											<ChatDateBadge text={formatTimestampSeparator(message.timestamp)} />
-										{/if}
 										<ChatMessage
 											myMessage={message.fromAddress === wallet.address ? true : false}
 											bubble

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -26,6 +26,12 @@
 	import Spacer from '$lib/components/spacer.svelte'
 	import Checkmark from '$lib/components/icons/checkmark.svelte'
 	import Close from '$lib/components/icons/close.svelte'
+	import {
+		areDifferentDays,
+		formatTimestampSeparator,
+		formatTimestampTime,
+	} from '$lib/utils/format'
+	import ChatDateBadge from '$lib/components/chat-date-badge.svelte'
 
 	let div: HTMLElement
 	let autoscroll = true
@@ -137,11 +143,21 @@
 						<div class="messages">
 							<div class="messages-inner">
 								<!-- Chat bubbles -->
-								{#each messages as message}
+								{#each messages as message, i}
 									{#if message.type === 'user' && message.text?.length > 0}
+										{@const lastMessage =
+											i + 1 === messages.length ||
+											messages[i].fromAddress !== messages[i + 1]?.fromAddress ||
+											messages[i + 1]?.type !== 'user'}
+										{#if i > 0 && areDifferentDays(messages[i].timestamp, messages[i - 1].timestamp)}
+											<ChatDateBadge text={formatTimestampSeparator(message.timestamp)} />
+										{/if}
 										<ChatMessage
 											myMessage={message.fromAddress === wallet.address ? true : false}
 											bubble
+											timestamp={lastMessage
+												? formatTimestampTime(lastMessage ? message.timestamp : 0)
+												: undefined}
 										>
 											{@html textToHTML(message.text)}
 										</ChatMessage>

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -30,6 +30,14 @@
 	import Settings from '$lib/components/icons/settings.svelte'
 	import { walletStore } from '$lib/stores/wallet'
 	import type { User } from '$lib/types'
+	import {
+		areDifferentDays,
+		formatTimestamp,
+		formatTimestampSeparator,
+		formatTimestampTime,
+	} from '$lib/utils/format'
+	import ChatDateBadge from '$lib/components/chat-date-badge.svelte'
+	import Timestamp from '$lib/components/timestamp.svelte'
 
 	let div: HTMLElement
 	let autoscroll = true
@@ -192,6 +200,9 @@
 											messages[i].fromAddress !== messages[i + 1]?.fromAddress ||
 											messages[i + 1]?.type !== 'user'}
 										{@const sender = chat.users.find((u) => message.fromAddress === u.address)}
+										{#if i > 0 && areDifferentDays(messages[i].timestamp, messages[i - 1].timestamp)}
+											<ChatDateBadge text={formatTimestampSeparator(message.timestamp)} />
+										{/if}
 										<ChatMessage
 											myMessage={message.fromAddress === wallet.address ? true : false}
 											bubble
@@ -200,6 +211,9 @@
 											senderName={message.fromAddress === wallet.address || !lastMessage
 												? undefined
 												: sender?.name}
+											timestamp={lastMessage
+												? formatTimestampTime(lastMessage ? message.timestamp : 0)
+												: undefined}
 										>
 											{@html replaceAddressesWithNames(textToHTML(htmlize(message.text)))}
 											<svelte:fragment slot="avatar">

--- a/src/routes/group/chat/[id]/+page.svelte
+++ b/src/routes/group/chat/[id]/+page.svelte
@@ -32,12 +32,10 @@
 	import type { User } from '$lib/types'
 	import {
 		areDifferentDays,
-		formatTimestamp,
 		formatTimestampSeparator,
 		formatTimestampTime,
 	} from '$lib/utils/format'
 	import ChatDateBadge from '$lib/components/chat-date-badge.svelte'
-	import Timestamp from '$lib/components/timestamp.svelte'
 
 	let div: HTMLElement
 	let autoscroll = true


### PR DESCRIPTION
Closes #32 

There were several simplifications compared to the original design: 
- [ ] In the design the timestamps are on the same line if the message is only one line
- [ ] The badges indicating the days are floating in the design, I just implemented them as markers between the chat bubbles.

![Screenshot from 2023-09-21 18-18-59](https://github.com/logos-innovation-lab/waku-objects-playground/assets/230163/94c6d857-50cd-4d0b-9df5-a2dda0d0547e)
