### PR TITLE
fix: invite redirect bug

### DIFF
--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -105,7 +105,7 @@
 					.filter(
 						(chat) =>
 							isGroupChatId(chat.chatId) &&
-							chat.users.find((user) => user.address === wallet.address),
+							chat.users.find((user) => user.address === inviter?.address),
 					)
 					.map((chat) => `"${chat.name}"`)
 					.slice(0, 1)}

--- a/src/routes/invite/[address]/+page.svelte
+++ b/src/routes/invite/[address]/+page.svelte
@@ -110,16 +110,20 @@
 	}
 
 	onMount(() => {
-		// make a copy of the list of chatIds when the screen is opened so that later we can compare
-		const oldChatIds = new Set($chats.chats.keys())
-		unsubscribe = chats.subscribe((store) => {
-			store.chats.forEach((value, key) => {
-				if (!oldChatIds.has(key) && !isGroupChatId(value.chatId)) {
-					// found new private chat
-					goto(routes.CHAT(value.chatId))
-				}
+		// when you show your QR code and link to someone, start looking for changes in the contacts
+		// and if a new contact is detected, redirect to their chat page
+		if (!$chats.loading && $page.params.address === $walletStore.wallet?.address) {
+			// make a copy of the list of chatIds when the screen is opened so that later we can compare
+			const oldChatIds = new Set($chats.chats.keys())
+			unsubscribe = chats.subscribe((store) => {
+				store.chats.forEach((value, key) => {
+					if (!oldChatIds.has(key) && !isGroupChatId(value.chatId)) {
+						// found new private chat
+						goto(routes.CHAT(value.chatId))
+					}
+				})
 			})
-		})
+		}
 	})
 
 	onDestroy(() => {


### PR DESCRIPTION
Currently the invite flow is buggy if you use an invite link from someone else you will be redirected to a random chat.

This PR fixes this, the root cause is that we did not check if the chat store is already loaded when saving the chat ids for later comparison, therefore the original set was empty and then when the chat store loaded it redirected you to a random chat from it.

The PR contains a check if the chat store is loaded and also the background detection should only start if you are the one sharing your link. I also added another fix for the join screen, it incorrectly showed your common groups with a contact because of an incorrect comparison.