### PR TITLE
fix: rename group

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -354,12 +354,10 @@ export default class WakuAdapter implements Adapter {
 			return
 		}
 
-		const updatedGroupChat = {
-			...groupChat,
-			name: name ?? groupChat.name,
-			avatar: avatar ?? groupChat.avatar,
-		}
-		await ws.setDoc<StorageChat>('group-chats', chatId, updatedGroupChat)
+		groupChat.name = name ?? groupChat.name
+		groupChat.avatar = avatar ?? groupChat.avatar
+
+		await ws.setDoc<StorageChat>('group-chats', chatId, groupChat)
 	}
 
 	async sendChatMessage(wallet: BaseWallet, chatId: string, text: string): Promise<void> {


### PR DESCRIPTION
resolves #402

Actually not sure if it was not fixed by some other PR anymore, but this works and is computationally more efficient.