### PR TITLE
feat: heic image support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"eslint-plugin-svelte3": "^4.0.0",
 		"ethers": "^6.6.4",
 		"hardhat": "^2.16.1",
+		"heic2any": "^0.0.4",
 		"html5-qrcode": "^2.3.8",
 		"ipfs-http-client": "^60.0.0",
 		"knip": "^2.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ devDependencies:
   hardhat:
     specifier: ^2.16.1
     version: 2.16.1(typescript@5.1.6)
+  heic2any:
+    specifier: ^0.0.4
+    version: 0.0.4
   html5-qrcode:
     specifier: ^2.3.8
     version: 2.3.8
@@ -4486,6 +4489,10 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: true
+
+  /heic2any@0.0.4:
+    resolution: {integrity: sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==}
     dev: true
 
   /hi-base32@0.5.1:

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -62,7 +62,6 @@ const allowedTypes = [
 ]
 
 function assertIsSupported(file: File) {
-	console.log(file.type)
 	if (!file.size || !file.type || !allowedTypes.includes(file.type))
 		throw new Error(`File not supported! File type: ${file.type}`)
 }
@@ -86,7 +85,6 @@ async function convertHeicToPng(heicFile: File): Promise<Blob> {
 		blob: heicFile,
 		toType: 'image/png',
 	})
-	console.log(out)
 	if (Array.isArray(out) && out[0]) return out[0]
 	if (out instanceof Blob) return out
 	throw new Error('Failed to convert HEIC to PNG')

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -68,7 +68,7 @@ function assertIsSupported(file: File) {
 }
 
 async function getFile(file: File): Promise<File> {
-	if (file.type === 'image/heic') {
+	if (file.type === 'image/heic' || file.type === 'image/heif') {
 		return new File([await convertHeicToPng(file)], file.name, { type: 'image/png' })
 	}
 	return file

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -59,6 +59,7 @@ const allowedTypes = [
 	'image/tiff',
 	'image/webp',
 	'image/heic',
+	'image/heif',
 ]
 
 function assertIsSupported(file: File) {


### PR DESCRIPTION
Resolves #430 

We have to lazy-load the library as it only works in browser. That's why there is:
```ts
	const heic2any = await import('heic2any')
	const out = await heic2any.default({
		blob: heicFile,
		toType: 'image/png',
	})
```