### PR TITLE
fix: change resubscribe timeout from 100 to 1000

### DIFF
--- a/src/lib/adapters/waku/safe-waku.ts
+++ b/src/lib/adapters/waku/safe-waku.ts
@@ -196,7 +196,7 @@ export class SafeWaku {
 				this.log(`⁉️ Error while resubscribing: ${e}`)
 
 				// sleep to avoid infinite looping
-				await sleep(100)
+				await sleep(1_000)
 			}
 		}
 


### PR DESCRIPTION
I find that 10 times a second is to excessive, it is better to wait one sec before retrying.