### PR TITLE
fix: load group info when starting the app

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -512,6 +512,18 @@ export default class WakuAdapter implements Adapter {
 	) {
 		const ws = await this.makeWakustore()
 
+		const groupChat = await ws.getDoc<StorageChat>('group-chats', groupChatId)
+		if (groupChat) {
+			const updatedGroupChat = await this.storageChatToChat(groupChatId, groupChat)
+			chats.updateChat(groupChatId, (chat) => ({
+				...chat,
+				chatId: groupChatId,
+				users: updatedGroupChat.users,
+				name: updatedGroupChat.name,
+				avatar: updatedGroupChat.avatar,
+			}))
+		}
+
 		const groupChatSubscription = await ws.onSnapshot<StorageChat>(
 			ws.docQuery('group-chats', groupChatId),
 			async (groupChat) => {


### PR DESCRIPTION
This PR fixes an issue when the group changes while you are offline. The fix is to load the state before subscribing to changes.