### PR TITLE
fix: badge for multiple digits or NEW text

### DIFF
--- a/src/lib/components/badge.svelte
+++ b/src/lib/components/badge.svelte
@@ -14,7 +14,6 @@
 		color: var(--color-step-40, var(--color-dark-step-20));
 		padding: var(--spacing-3) var(--spacing-6);
 		text-transform: uppercase;
-		min-width: 22px;
 		text-align: center;
 		white-space: nowrap;
 


### PR DESCRIPTION
resolves #335

![Screenshot 2023-10-02 at 9 02 31](https://github.com/logos-innovation-lab/waku-objects-playground/assets/7974813/6399e6f8-f65a-40c2-9d51-a1033a5cacab)
