### PR TITLE
fix: waku improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@waku-objects/luminance": "^2.0.1",
 		"@waku-objects/sandbox-example": "^0.4.0",
 		"@waku/interfaces": "^0.0.15",
-		"@waku/sdk": "^0.0.16",
+		"@waku/sdk": "^0.0.19",
 		"copy-to-clipboard": "^3.3.3",
 		"eslint": "^8.44.0",
 		"eslint-config-prettier": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@typescript-eslint/parser": "^5.61.0",
 		"@waku-objects/luminance": "^2.0.1",
 		"@waku-objects/sandbox-example": "^0.4.0",
-		"@waku/interfaces": "^0.0.15",
+		"@waku/interfaces": "^0.0.18",
 		"@waku/sdk": "^0.0.19",
 		"copy-to-clipboard": "^3.3.3",
 		"eslint": "^8.44.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ devDependencies:
     specifier: ^0.0.15
     version: 0.0.15
   '@waku/sdk':
-    specifier: ^0.0.16
-    version: 0.0.16(@multiformats/multiaddr@12.1.3)
+    specifier: ^0.0.19
+    version: 0.0.19(@multiformats/multiaddr@12.1.3)
   copy-to-clipboard:
     specifier: ^3.3.3
     version: 3.3.3
@@ -127,26 +127,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@achingbrain/ip-address@8.1.0:
-    resolution: {integrity: sha512-Zus4vMKVRDm+R1o0QJNhD0PD/8qRGO3Zx8YPsFG5lANt5utVtGg3iHVGBSAF80TfQmhi8rP+Kg/OigdxY0BXHw==}
-    engines: {node: '>= 12'}
-    dependencies:
-      jsbn: 1.1.0
-      sprintf-js: 1.1.2
-    dev: true
-
-  /@achingbrain/nat-port-mapper@1.0.8:
-    resolution: {integrity: sha512-FKiV8cAfpjJd6GG4E+iuShnJIpj8Ro36lKlfyMlYepXlmID0q5h7pTG5ha61FHigpouT3CQc5ZTAwXiDsVCSCA==}
+  /@achingbrain/nat-port-mapper@1.0.11:
+    resolution: {integrity: sha512-Y2lwx0zmrwEl+IGu+V/QiVBdcdsWscYq1PMMEjvyuuaXnmnppbLWilO8LK1yoLdncxwJBuS0zZtHbpFeWBusRg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       '@achingbrain/ssdp': 4.0.4
-      '@libp2p/logger': 2.0.7
-      default-gateway: 6.0.3
+      '@libp2p/logger': 3.0.3
+      default-gateway: 7.2.2
       err-code: 3.0.1
       it-first: 3.0.2
       p-defer: 4.0.0
-      p-timeout: 5.1.0
-      xml2js: 0.5.0
+      p-timeout: 6.1.1
+      xml2js: 0.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -189,61 +181,54 @@ packages:
     resolution: {integrity: sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ==}
     dev: true
 
-  /@chainsafe/libp2p-gossipsub@6.3.0:
-    resolution: {integrity: sha512-yRgMB5JpyPROjmhOeOmzJUAKci19qBEnpH80201f8JkkviUJo7+X8i3MUkammlbFg0VhaTKBT98Osbko9+rT1w==}
+  /@chainsafe/is-ip@2.0.2:
+    resolution: {integrity: sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA==}
+    dev: true
+
+  /@chainsafe/libp2p-gossipsub@10.1.0:
+    resolution: {integrity: sha512-mOVYJAvxYRkh2HeggNFW/7ukEccQDVEI9LPhvlnJk7gnJhyJJ6mhZxUAaytfp3v3qTkmeBRnEL0eJOQBm+MoOA==}
     engines: {npm: '>=8.7.0'}
     dependencies:
-      '@libp2p/crypto': 1.0.17
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interface-connection-manager': 1.5.0
-      '@libp2p/interface-keys': 1.0.8
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-store': 1.2.9
-      '@libp2p/interface-pubsub': 3.0.7
-      '@libp2p/interface-registrar': 2.0.12
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      '@libp2p/peer-id': 2.0.3
-      '@libp2p/peer-record': 5.0.3
-      '@libp2p/pubsub': 6.0.6
-      '@libp2p/topology': 4.0.1
-      '@multiformats/multiaddr': 12.1.3
-      abortable-iterator: 4.0.3
-      denque: 1.5.1
-      it-length-prefixed: 8.0.4
-      it-pipe: 2.0.5
-      it-pushable: 3.1.3
-      multiformats: 11.0.2
-      protobufjs: 6.11.3
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/interface-internal': 0.1.6
+      '@libp2p/logger': 3.0.3
+      '@libp2p/peer-id': 3.0.3
+      '@libp2p/pubsub': 8.0.7
+      '@multiformats/multiaddr': 12.1.7
+      abortable-iterator: 5.0.1
+      denque: 2.1.0
+      it-length-prefixed: 9.0.1
+      it-pipe: 3.0.1
+      it-pushable: 3.2.1
+      multiformats: 12.1.2
+      protobufjs: 7.2.5
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@chainsafe/libp2p-noise@11.0.4:
-    resolution: {integrity: sha512-X7kA6a3/QPFxNFwgUJ8vubDu5qBDcDT0nhD+jL7g60IFKZu//HFH7oqsNCZa12yx0oR1fEYOR62iHDt2GHyWBQ==}
+  /@chainsafe/libp2p-noise@13.0.1:
+    resolution: {integrity: sha512-eeOFubXyS9sK0oBg/qRfve6LVGzZX1vyULVidaKGTJr8Y4dtyU4+Btqw/aVo3o1lhdvb/qoY+p/Ep2pUsvJKhg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
-      '@libp2p/crypto': 1.0.17
-      '@libp2p/interface-connection-encrypter': 3.0.6
-      '@libp2p/interface-keys': 1.0.8
-      '@libp2p/interface-metrics': 4.0.8
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/logger': 2.0.7
-      '@libp2p/peer-id': 2.0.3
-      '@stablelib/chacha20poly1305': 1.0.1
-      '@stablelib/hkdf': 1.0.1
-      '@stablelib/sha256': 1.0.1
-      '@stablelib/x25519': 1.0.3
-      it-length-prefixed: 8.0.4
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
+      '@libp2p/peer-id': 3.0.3
+      '@noble/ciphers': 0.3.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      it-byte-stream: 1.0.1
+      it-length-prefixed: 9.0.1
+      it-length-prefixed-stream: 1.0.2
       it-pair: 2.0.6
-      it-pb-stream: 3.2.1
-      it-pipe: 2.0.5
-      it-stream-types: 1.0.5
+      it-pipe: 3.0.1
+      it-stream-types: 2.0.1
       protons-runtime: 5.0.0
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1207,56 +1192,27 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       '@libp2p/interface-keys': 1.0.8
-      '@libp2p/interfaces': 3.3.1
+      '@libp2p/interfaces': 3.3.2
       '@noble/ed25519': 1.7.3
       '@noble/secp256k1': 1.7.1
       multiformats: 11.0.2
       node-forge: 1.3.1
       protons-runtime: 5.0.0
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     dev: true
 
-  /@libp2p/interface-address-manager@2.0.5:
-    resolution: {integrity: sha512-e2vLstKkYlAG2PZe6SEBpnnP2Y/ej6URue+zAiyjJPuXoOGNzHyLaqcv7MKye171OEf9dg5wv1gFphWcUJJbSA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/crypto@2.0.5:
+    resolution: {integrity: sha512-m6Rn7i9q3SHCzMUBkEwZgAKS4evpGQ4SEx/YD96pM0ZoPtU5PFO0psfrerraanxFBh8wUX4vkCtKfyTPH7F+bQ==}
     dependencies:
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-connection-encrypter@3.0.6:
-    resolution: {integrity: sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      it-stream-types: 1.0.5
+      '@libp2p/interface': 0.1.3
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      multiformats: 12.1.2
+      node-forge: 1.3.1
+      protons-runtime: 5.0.0
       uint8arraylist: 2.4.3
-    dev: true
-
-  /@libp2p/interface-connection-manager@1.5.0:
-    resolution: {integrity: sha512-luqYVMH3yip12JlSwVmBdo5/qG4YnXQXp2AV4lvxWK0sUhCnI2r3YL4e9ne8o3LAA5CkH3lPqTQ2HSRpmOruFg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-connection@3.1.1:
-    resolution: {integrity: sha512-+hxfYLv4jf+MruQEJiJeIyo/wI33/53wRL0XJTkxwQQPAkLHfZWCUY4kY9sXALd3+ASjXAENvJj9VvzZTlkRDQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-      it-stream-types: 1.0.5
-      uint8arraylist: 2.4.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1274,39 +1230,13 @@ packages:
       - supports-color
     dev: true
 
-  /@libp2p/interface-connection@5.1.0:
-    resolution: {integrity: sha512-KFjCnGvFVlu0hHS/O8NOsst32mIzUQEkRWq5EhOBehXjjpOJBcm8XQaqmhBlxVfHEYm7XQsztEtFumveszzm1A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/interface-internal@0.1.6:
+    resolution: {integrity: sha512-n4Sv9tSr+2QRN7tHShmUJILQRoIPRPPkl0Zr8mVOW91XcdN2CfLYrzqeM1Yvl/iZx98bNMZXJveZV9OVuBynuQ==}
     dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-      it-stream-types: 2.0.1
+      '@libp2p/interface': 0.1.3
+      '@libp2p/peer-collections': 4.0.5
+      '@multiformats/multiaddr': 12.1.7
       uint8arraylist: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-content-routing@2.1.1:
-    resolution: {integrity: sha512-nRPOUWgq1K1fDr3FKW93Tip7aH8AFefCw3nJygL4crepxWTSGw95s1GyDpC7t0RJkWTRNHsqZvsFsJ9FkHExKw==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interfaces': 3.3.1
-      multiformats: 11.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-dht@2.0.3:
-    resolution: {integrity: sha512-JAKbHvw3egaSeB7CHOf6PF/dLNim4kzAiXX+0IEz2lln8L32/Xf1T7KNOF/RSbSYqO9b7Xxc/b2fuSfyaMwwMQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-discovery': 2.0.0
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interfaces': 3.3.1
-      multiformats: 11.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1324,56 +1254,6 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /@libp2p/interface-libp2p@1.3.3:
-    resolution: {integrity: sha512-7kEoIlAGTIiUNJ/4vIFWx+j+iN4aco7O2PqH6ES3dTvX6sgvYxYFi83p1G/RDj8tHKO7jLfG3UmiwJc/Ab0VyA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-connection': 5.1.0
-      '@libp2p/interface-content-routing': 2.1.1
-      '@libp2p/interface-dht': 2.0.3
-      '@libp2p/interface-keychain': 2.0.4
-      '@libp2p/interface-metrics': 4.0.8
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interface-peer-routing': 1.1.1
-      '@libp2p/interface-peer-store': 1.2.9
-      '@libp2p/interface-pubsub': 4.0.1
-      '@libp2p/interface-registrar': 2.0.12
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-metrics@4.0.8:
-    resolution: {integrity: sha512-1b9HjYyJH0m35kvPHipuoz2EtYCxyq34NUhuV8VK1VNtrouMpA3uCKp5FI7yHCA6V6+ux1R3UriKgNFOSGbIXQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-connection': 5.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-peer-discovery@1.1.1:
-    resolution: {integrity: sha512-tjbt5DquTyP/JDskasPbIB3lk+zPVL8J9UPfrELZqlslJo9ufsMKyEXcTMMABclTvUsh6uSDgC0JUpUHTeCn8A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interfaces': 3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-peer-discovery@2.0.0:
-    resolution: {integrity: sha512-Mien5t3Tc+ntP5p50acKUYJN90ouMnq1lOTQDKQNvGcXoajG8A1AEYLocnzVia/MXiexuj6S/Q28WBBacoOlBg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interfaces': 3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@libp2p/interface-peer-id@2.0.1:
     resolution: {integrity: sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -1383,40 +1263,6 @@ packages:
 
   /@libp2p/interface-peer-info@1.0.9:
     resolution: {integrity: sha512-XewuwXMVYMcwaxhH9PFVfsFNEXi2OEe9TgkBwvZbbtwTI2Cz6zvKS1tT4f+ATCXjQbN840Nhe6ETPQ4TfhThOQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@multiformats/multiaddr': 12.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-peer-routing@1.1.1:
-    resolution: {integrity: sha512-/XEhwob9qXjdmI8PBcc+qFin32xmtyoC58nRpq8RliqHY5uOVWiHfZoNtdOXIsNvzVvq5FqlHOWt71ofxXTtlg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interfaces': 3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-peer-store@1.2.9:
-    resolution: {integrity: sha512-jAAlbP1NXpEJOG6Dbr0QdP71TBYjHBc/65Ulwdn4J4f04PW1bI4JIMQeq6+/sLfaGVryvvUT/a52io8UUtB21Q==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interface-record': 2.0.7
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-peer-store@2.0.3:
-    resolution: {integrity: sha512-xOVjzJCs3qhpUVUmOg3n8E8PUuUrmtzL9G8+Ht1HO+PJQX4HsyDjIgeUnSAnp6XBtiRyx5E/bE0xqThGZskPuQ==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       '@libp2p/interface-peer-id': 2.0.1
@@ -1438,57 +1284,17 @@ packages:
       - supports-color
     dev: true
 
-  /@libp2p/interface-pubsub@4.0.1:
-    resolution: {integrity: sha512-PIc5V/J98Yr1ZTHh8lQshP7GdVUh+pKNIqj6wGaDmXs8oQLB40qKCjcpHQNlAnv2e1Bh9mEH2GXv5sGZOA651A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/interface@0.1.3:
+    resolution: {integrity: sha512-C1O7Xqd2TGVWrIOEDx6kGJSk4YOysWGmYG5Oh3chnsCY0wjUSsLDpl9+wKrdiM/lJbAlHlV65ZOvSkIQ9cWPBQ==}
     dependencies:
-      '@libp2p/interface-connection': 5.1.0
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interfaces': 3.3.1
-      it-pushable: 3.1.3
+      '@multiformats/multiaddr': 12.1.7
+      abortable-iterator: 5.0.1
+      it-pushable: 3.2.1
+      it-stream-types: 2.0.1
+      multiformats: 12.1.2
+      p-defer: 4.0.0
+      race-signal: 1.0.1
       uint8arraylist: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-record@2.0.7:
-    resolution: {integrity: sha512-AFPytZWI+p8FJWP0xuK5zbSjalLAOIMzEed2lBKdRWvdGBQUHt9ENLTkfkI9G7p/Pp3hlhVzzBXdIErKd+0GxQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      uint8arraylist: 2.4.3
-    dev: true
-
-  /@libp2p/interface-registrar@2.0.12:
-    resolution: {integrity: sha512-EyCi2bycC2rn3oPB4Swr7EqBsvcaWd6RcqR6zsImNIG9BKc4/R1gl6iaF861JaELYgYmzBMS31x1rQpVz5UekQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-connection': 5.1.0
-      '@libp2p/interface-peer-id': 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-stream-muxer@3.0.6:
-    resolution: {integrity: sha512-wbLrH/bdF8qe0CpPd3BFMSmUs085vc3/8zx5uhXJySD672enAc8Jw9gmAYd1pIqELdqJqBDg9EI0y1XMRxvVkw==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interfaces': 3.3.1
-      it-stream-types: 1.0.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/interface-transport@2.1.3:
-    resolution: {integrity: sha512-ez+0X+w2Wyw3nJY6mP0DHFgrRnln/miAH4TJLcRfUSJHjGXH5ZfpuK1TnRxXpEUiqOezSbwke06/znI27KpRiQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interface-stream-muxer': 3.0.6
-      '@libp2p/interfaces': 3.3.1
-      '@multiformats/multiaddr': 12.1.3
-      it-stream-types: 1.0.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1496,6 +1302,26 @@ packages:
   /@libp2p/interfaces@3.3.1:
     resolution: {integrity: sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: true
+
+  /@libp2p/interfaces@3.3.2:
+    resolution: {integrity: sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: true
+
+  /@libp2p/keychain@3.0.5:
+    resolution: {integrity: sha512-D8Tisc5yi2+ykM4Yw4Qsan/hGITF+jfHMC6Nti1upOOLAhGFpm92if/hkb2rZH3Q1iXs7l3fIhgOs9VayNplhA==}
+    dependencies:
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
+      '@libp2p/peer-id': 3.0.3
+      interface-datastore: 8.2.0
+      merge-options: 3.0.4
+      sanitize-filename: 1.6.3
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@libp2p/logger@2.0.7:
@@ -1510,69 +1336,76 @@ packages:
       - supports-color
     dev: true
 
-  /@libp2p/mplex@7.1.7:
-    resolution: {integrity: sha512-8eJ6HUL3bM8ck0rb/NJ04+phBUVBMocxH/kuc2Nypn8RX9ezihV7srGGhG5N7muaMwJrRbYkFhIV4GH+8WTZUg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/logger@3.0.3:
+    resolution: {integrity: sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==}
     dependencies:
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interface-stream-muxer': 3.0.6
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      abortable-iterator: 4.0.3
-      any-signal: 4.1.1
-      benchmark: 2.1.4
-      it-batched-bytes: 1.0.1
-      it-pushable: 3.1.3
-      it-stream-types: 1.0.5
-      rate-limiter-flexible: 2.4.1
-      uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
-      varint: 6.0.0
+      '@libp2p/interface': 0.1.3
+      '@multiformats/multiaddr': 12.1.7
+      debug: 4.3.4(supports-color@8.1.1)
+      interface-datastore: 8.2.0
+      multiformats: 12.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@libp2p/multistream-select@3.1.8:
-    resolution: {integrity: sha512-Ap6b3+69+j4R3KbqlQsHaa2OHGc2+YwwJcGU+VdiRS+RDM5mQdOjG0mGW2mRFDwrQKq9UZIkxo8hwzCZNkxFjA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/mplex@9.0.8:
+    resolution: {integrity: sha512-NHsoBWEImqr7nVNujNmedFW5ctefPG4kMAW0+UhLwJsq6X0p3qtaGbAAQZm6PqI7KIE16lEXFJkZfFFgMOpXJQ==}
     dependencies:
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
+      abortable-iterator: 5.0.1
+      benchmark: 2.1.4
+      it-batched-bytes: 2.0.4
+      it-pushable: 3.2.1
+      it-stream-types: 2.0.1
+      rate-limiter-flexible: 3.0.0
+      uint8-varint: 2.0.1
+      uint8arraylist: 2.4.3
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@libp2p/multistream-select@4.0.3:
+    resolution: {integrity: sha512-6iBYf/TAqi0oqusZ3LJ3DC0odABRukuLN+4Xh7tDmHCJX0tCjSSRibRYsiFcBNQMpcI0btRkQ0dZ0KqKhQ2kUw==}
+    dependencies:
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
       abortable-iterator: 5.0.1
       it-first: 3.0.2
       it-handshake: 4.1.3
       it-length-prefixed: 9.0.1
       it-merge: 3.0.1
       it-pipe: 3.0.1
-      it-pushable: 3.1.3
+      it-pushable: 3.2.1
       it-reader: 6.0.4
       it-stream-types: 2.0.1
+      uint8-varint: 2.0.1
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@libp2p/peer-collections@3.0.1:
-    resolution: {integrity: sha512-tJvCjFSKX76VacThVnN0XC4jnUeufYD2u9TxWJllSYnmmos/Lwhl4kdtEyZkKNlJKam+cBoUmODXzasdoPZgVg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/peer-collections@4.0.5:
+    resolution: {integrity: sha512-GdbVufdDLhYyHbDBO2juK54Nm+Cdu01ws0N0hNB0yVLM7GIP075RLgSO/0vTpLoPS1cEufKPsYfl4Bb5nKHaRg==}
     dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/peer-id': 2.0.3
+      '@libp2p/interface': 0.1.3
+      '@libp2p/peer-id': 3.0.3
     dev: true
 
-  /@libp2p/peer-id-factory@2.0.3:
-    resolution: {integrity: sha512-9pwVbfghiKuiC76Pue/+tI4PD7gnw1jGVcxYD+nhcRs8ABE7NLaB7nCm99cCtvmMNRnl2JqaGgZJXt8mnvAEuQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/peer-id-factory@3.0.5:
+    resolution: {integrity: sha512-i7h/u3zDvcj8+GR+kpazmjikr3A6Rr5flVZmrTZfarkq5qAmD1bWd0vbgPrtKEgbhT+1S8NL3jR05/n7cbF7Tw==}
     dependencies:
-      '@libp2p/crypto': 1.0.17
-      '@libp2p/interface-keys': 1.0.8
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/peer-id': 2.0.3
-      multiformats: 11.0.2
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/peer-id': 3.0.3
+      multiformats: 12.1.2
       protons-runtime: 5.0.0
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@libp2p/peer-id@2.0.3:
@@ -1585,110 +1418,80 @@ packages:
       uint8arrays: 4.0.3
     dev: true
 
-  /@libp2p/peer-record@5.0.3:
-    resolution: {integrity: sha512-KnQR/NteL0xGKXd9rZo/W3ZT9kajmNy98/BOOlnMktkAL7jCfHy2z/laDU+rSttTy1TYZ15zPzXtnm3813ECmg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/peer-id@3.0.3:
+    resolution: {integrity: sha512-IPVeywoC40bDd3ohtAIzpN8AOkMmD3U0BjdrFz/5ZbNP1+4n2gDIAwVzkAbF/t1iYYS4CX1TWfHuMqaMvd8l1A==}
     dependencies:
-      '@libp2p/crypto': 1.0.17
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-record': 2.0.7
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/peer-id': 2.0.3
-      '@libp2p/utils': 3.0.11
-      '@multiformats/multiaddr': 12.1.3
+      '@libp2p/interface': 0.1.3
+      multiformats: 12.1.2
+      uint8arrays: 4.0.6
+    dev: true
+
+  /@libp2p/peer-record@6.0.6:
+    resolution: {integrity: sha512-SNFafmUrnEOB2zplYJVjheN5UVFbi2UBdrYfIwi4SEaPA4ZFprnWBeQcVaLUSq7t2JkBGZUmWwtj4teVIxr60g==}
+    dependencies:
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/peer-id': 3.0.3
+      '@libp2p/utils': 4.0.4
+      '@multiformats/multiaddr': 12.1.7
       protons-runtime: 5.0.0
-      uint8-varint: 1.0.6
+      uint8-varint: 2.0.1
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@libp2p/peer-store@6.0.4:
-    resolution: {integrity: sha512-yw7XbeJ5k880PpkDV/HcSZtj0vQ0ShPbnCzVHc1hW0JS/g1vhpSooAZOf3w65obUoFhUwccnSZ4HSLBSpQqOaA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/peer-store@9.0.6:
+    resolution: {integrity: sha512-aBAvRKKg2Hsf0/bGrHEcxr6cGL8RDJhBx2xBhNuu7sROMd0isPrKNxfnrQKadYMxlQUnGzIEY3qFVQJJPFHZvA==}
     dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interface-peer-store': 1.2.9
-      '@libp2p/interface-record': 2.0.7
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      '@libp2p/peer-id': 2.0.3
-      '@libp2p/peer-record': 5.0.3
-      '@multiformats/multiaddr': 11.6.1
-      interface-datastore: 7.0.4
-      it-all: 2.0.1
-      it-filter: 2.0.2
-      it-foreach: 1.0.1
-      it-map: 2.0.1
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
+      '@libp2p/peer-collections': 4.0.5
+      '@libp2p/peer-id': 3.0.3
+      '@libp2p/peer-id-factory': 3.0.5
+      '@libp2p/peer-record': 6.0.6
+      '@multiformats/multiaddr': 12.1.7
+      interface-datastore: 8.2.0
+      it-all: 3.0.2
       mortice: 3.0.1
-      multiformats: 11.0.2
+      multiformats: 12.1.2
       protons-runtime: 5.0.0
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@libp2p/pubsub@6.0.6:
-    resolution: {integrity: sha512-/JU4xvtZIYDxOyiHIk4MlpnAJuqfZsabDP+4f59QlXNsppOmiIujaDhN3eFBFIKG29XDSgHZBzKMLK+XsB8O5g==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/pubsub@8.0.7:
+    resolution: {integrity: sha512-gpkKNMlxdF/tObBPE/3pY3aItfleLWUr7ghEpnK2CcRWkmb+ZACGC2MrYM9IbdHn3/jfQFSWoxJwMcoFJ8IJ0w==}
     dependencies:
-      '@libp2p/crypto': 1.0.17
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-pubsub': 3.0.7
-      '@libp2p/interface-registrar': 2.0.12
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      '@libp2p/peer-collections': 3.0.1
-      '@libp2p/peer-id': 2.0.3
-      '@libp2p/topology': 4.0.1
-      abortable-iterator: 4.0.3
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/interface-internal': 0.1.6
+      '@libp2p/logger': 3.0.3
+      '@libp2p/peer-collections': 4.0.5
+      '@libp2p/peer-id': 3.0.3
+      abortable-iterator: 5.0.1
       it-length-prefixed: 9.0.1
       it-pipe: 3.0.1
-      it-pushable: 3.1.3
-      multiformats: 11.0.2
+      it-pushable: 3.2.1
+      multiformats: 12.1.2
       p-queue: 7.3.4
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@libp2p/topology@4.0.1:
-    resolution: {integrity: sha512-wcToZU3o55nTPuN+yEpAublGzomGfxEAu8snaGeZS0f6ObzaQXqPgZvD5qpiQ8yOOVjR+IiNEjZJiuqNShHnaA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/utils@4.0.4:
+    resolution: {integrity: sha512-V++nWaCEO5QBk800SJ3kzzVn62cyBLt7fzVPDvVnxPyfLBn9prfShYb7XmvuZrnGSRCaUvD3b+q7CHGUEcdP2g==}
     dependencies:
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-registrar': 2.0.12
-      '@libp2p/logger': 2.0.7
-      it-all: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/tracked-map@3.0.2:
-    resolution: {integrity: sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@libp2p/interface-metrics': 4.0.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@libp2p/utils@3.0.11:
-    resolution: {integrity: sha512-d8ZQnu2o78TG7Oy4G6qFy5v/kNBtfgQjy1RpiQAEAB6AOSi1Oq8nLebrgCqSHfrtOIcj6a+G6ImYBaRE4b03CA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      '@achingbrain/ip-address': 8.1.0
-      '@libp2p/interface-connection': 5.1.0
-      '@libp2p/interface-peer-store': 2.0.3
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      '@multiformats/multiaddr': 12.1.3
-      abortable-iterator: 5.0.1
+      '@chainsafe/is-ip': 2.0.2
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
+      '@multiformats/multiaddr': 12.1.7
+      '@multiformats/multiaddr-matcher': 1.0.2
       is-loopback-addr: 2.0.1
       it-stream-types: 2.0.1
       private-ip: 3.0.0
@@ -1697,22 +1500,19 @@ packages:
       - supports-color
     dev: true
 
-  /@libp2p/websockets@5.0.10:
-    resolution: {integrity: sha512-q8aKm0rhDxZjc4TzDpB0quog4pViFnz+Ok+UbGEk3xXxHwT3QCxaDVPKMemMqN/1N3OahVvcodpcvFSuWmus+A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@libp2p/websockets@7.0.9:
+    resolution: {integrity: sha512-+MJKxGrLSv/aSHpdhlc05sVVPWg9TVJMCHfpN3WXG0B9DVk/qLdX+mCHpmPvRRdrDoYx6QfWvzHmhDHwfKNAdg==}
     dependencies:
-      '@libp2p/interface-connection': 4.0.0
-      '@libp2p/interface-transport': 2.1.3
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      '@libp2p/utils': 3.0.11
+      '@libp2p/interface': 0.1.3
+      '@libp2p/logger': 3.0.3
+      '@libp2p/utils': 4.0.4
       '@multiformats/mafmt': 12.1.3
-      '@multiformats/multiaddr': 12.1.3
+      '@multiformats/multiaddr': 12.1.7
       '@multiformats/multiaddr-to-uri': 9.0.4
-      abortable-iterator: 4.0.3
-      it-ws: 5.0.6
+      '@types/ws': 8.5.6
+      abortable-iterator: 5.0.1
+      it-ws: 6.0.5
       p-defer: 4.0.0
-      p-timeout: 6.1.1
       wherearewe: 2.0.1
       ws: 8.13.0
     transitivePeerDependencies:
@@ -1732,19 +1532,20 @@ packages:
       tweetnacl-util: 0.15.1
     dev: true
 
-  /@multiformats/mafmt@11.1.2:
-    resolution: {integrity: sha512-3n1o5eLU7WzTAPLuz3AodV7Iql6NWf7Ws8fqVaGT7o5nDDabUPYGBm2cZuh3OrqmwyCY61LrNUIsjzivU6UdpQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /@multiformats/mafmt@12.1.3:
+    resolution: {integrity: sha512-F9W98CkdH7UR7CrLZ35jh9GrizbUBZsFSUwXdWAqu+Kf99vx67EU60g2QU1OABvkYrMKr8Jr9oKYY17wdtR+hQ==}
     dependencies:
-      '@multiformats/multiaddr': 12.1.3
+      '@multiformats/multiaddr': 12.1.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@multiformats/mafmt@12.1.3:
-    resolution: {integrity: sha512-F9W98CkdH7UR7CrLZ35jh9GrizbUBZsFSUwXdWAqu+Kf99vx67EU60g2QU1OABvkYrMKr8Jr9oKYY17wdtR+hQ==}
+  /@multiformats/multiaddr-matcher@1.0.2:
+    resolution: {integrity: sha512-YzviFV31TsDbatWhEmkNnpWC82F/Wfc+alaOBT94Lk6KJeKKfzsaLhYPsjyhElXiUtCKvB3p5e4+WsE5ZYy1kg==}
     dependencies:
-      '@multiformats/multiaddr': 12.1.3
+      '@chainsafe/is-ip': 2.0.1
+      '@multiformats/multiaddr': 12.1.7
+      multiformats: 12.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1787,6 +1588,31 @@ packages:
       - supports-color
     dev: true
 
+  /@multiformats/multiaddr@12.1.7:
+    resolution: {integrity: sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==}
+    engines: {node: '>=18.0.0', npm: '>=8.6.0'}
+    dependencies:
+      '@chainsafe/is-ip': 2.0.1
+      '@chainsafe/netmask': 2.0.0
+      '@libp2p/interface': 0.1.3
+      dns-over-http-resolver: 2.1.1
+      multiformats: 12.1.2
+      uint8-varint: 2.0.1
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@noble/ciphers@0.3.0:
+    resolution: {integrity: sha512-ldbrnOjmNRwFdXcTM6uXDcxpMIFrbzAWNnpBPp4oTJTFF0XByGD6vf45WrehZGXRQTRVV+Zm8YP+EgEf+e4cWA==}
+    dev: true
+
+  /@noble/curves@1.2.0:
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: true
+
   /@noble/ed25519@1.7.3:
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
     dev: true
@@ -1799,8 +1625,9 @@ packages:
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
     dev: true
 
-  /@noble/hashes@1.3.0:
-    resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
+  /@noble/hashes@1.3.2:
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
     dev: true
 
   /@noble/secp256k1@1.7.1:
@@ -2264,106 +2091,6 @@ packages:
       p-map: 4.0.0
     dev: true
 
-  /@stablelib/aead@1.0.1:
-    resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
-    dev: true
-
-  /@stablelib/binary@1.0.1:
-    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
-    dependencies:
-      '@stablelib/int': 1.0.1
-    dev: true
-
-  /@stablelib/bytes@1.0.1:
-    resolution: {integrity: sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==}
-    dev: true
-
-  /@stablelib/chacha20poly1305@1.0.1:
-    resolution: {integrity: sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==}
-    dependencies:
-      '@stablelib/aead': 1.0.1
-      '@stablelib/binary': 1.0.1
-      '@stablelib/chacha': 1.0.1
-      '@stablelib/constant-time': 1.0.1
-      '@stablelib/poly1305': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/chacha@1.0.1:
-    resolution: {integrity: sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==}
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/constant-time@1.0.1:
-    resolution: {integrity: sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==}
-    dev: true
-
-  /@stablelib/hash@1.0.1:
-    resolution: {integrity: sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==}
-    dev: true
-
-  /@stablelib/hkdf@1.0.1:
-    resolution: {integrity: sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==}
-    dependencies:
-      '@stablelib/hash': 1.0.1
-      '@stablelib/hmac': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/hmac@1.0.1:
-    resolution: {integrity: sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==}
-    dependencies:
-      '@stablelib/constant-time': 1.0.1
-      '@stablelib/hash': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/int@1.0.1:
-    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
-    dev: true
-
-  /@stablelib/keyagreement@1.0.1:
-    resolution: {integrity: sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==}
-    dependencies:
-      '@stablelib/bytes': 1.0.1
-    dev: true
-
-  /@stablelib/poly1305@1.0.1:
-    resolution: {integrity: sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==}
-    dependencies:
-      '@stablelib/constant-time': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/random@1.0.2:
-    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/sha256@1.0.1:
-    resolution: {integrity: sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==}
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/hash': 1.0.1
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
-  /@stablelib/wipe@1.0.1:
-    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
-    dev: true
-
-  /@stablelib/x25519@1.0.3:
-    resolution: {integrity: sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==}
-    dependencies:
-      '@stablelib/keyagreement': 1.0.1
-      '@stablelib/random': 1.0.2
-      '@stablelib/wipe': 1.0.1
-    dev: true
-
   /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.21.0):
     resolution: {integrity: sha512-o2pZCfATFtA/Gw/BB0Xm7k4EYaekXxaPGER3xGSY3FvzFJGTlJlZjBseaXwYSM94lZ0HniOjTokN3cWaLX6fow==}
     peerDependencies:
@@ -2488,10 +2215,6 @@ packages:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
-  /@types/long@4.0.2:
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-    dev: true
-
   /@types/lru-cache@5.1.1:
     resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
     dev: true
@@ -2529,8 +2252,8 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
-  /@types/retry@0.12.1:
-    resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
+  /@types/retry@0.12.2:
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
     dev: true
 
   /@types/secp256k1@4.0.3:
@@ -2541,6 +2264,12 @@ packages:
 
   /@types/semver@7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
+
+  /@types/ws@8.5.6:
+    resolution: {integrity: sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==}
+    dependencies:
+      '@types/node': 20.5.4
     dev: true
 
   /@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0)(eslint@8.44.0)(typescript@5.1.6):
@@ -2736,26 +2465,26 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@waku/core@0.0.20(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2):
-    resolution: {integrity: sha512-1p8TmOvbGhUQZHKE+w1FQtmp+EDTNQEsSgrsMoSjzGVdI+XuQQ/l2aefwOuBQHIHh99+VZBQ9ut+ArstFHks/A==}
+  /@waku/core@0.0.23(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13):
+    resolution: {integrity: sha512-F3gR315O6RaGAGLUcXbcdkOSFTgjt1b6e0mU9zdLQrL+ifRKxODVqz8g1zh4jqsv8U8rsvOWN+YNPciu7LYmxQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@multiformats/multiaddr': ^12.0.0
-      libp2p: ^0.42.2
+      libp2p: ^0.46.3
     peerDependenciesMeta:
       '@multiformats/multiaddr':
         optional: true
     dependencies:
       '@multiformats/multiaddr': 12.1.3
-      '@noble/hashes': 1.3.0
-      '@waku/interfaces': 0.0.15
+      '@noble/hashes': 1.3.2
+      '@waku/interfaces': 0.0.18
       '@waku/proto': 0.0.5
-      '@waku/utils': 0.0.8
+      '@waku/utils': 0.0.11
       debug: 4.3.4(supports-color@8.1.1)
-      it-all: 3.0.2
+      it-all: 3.0.3
       it-length-prefixed: 9.0.1
       it-pipe: 3.0.1
-      libp2p: 0.42.2
+      libp2p: 0.46.13
       p-event: 5.0.1
       uint8arraylist: 2.4.3
       uuid: 9.0.0
@@ -2763,32 +2492,30 @@ packages:
       - supports-color
     dev: true
 
-  /@waku/dns-discovery@0.0.14:
-    resolution: {integrity: sha512-S8kzLUvmqIuqLGcPAT6JAYFDrxB/TeMEihU4tsWWg7UBnxyQVH2lqkjzGxnqClrQ9XFukvlH1fhvn0AIkKg25A==}
+  /@waku/dns-discovery@0.0.17:
+    resolution: {integrity: sha512-sZQRSdDut+wjxgvciXGhMbYS5vl5aGsAFjNddHVHERRWt5kFWZ0ci5a+EsJwOYSytM3c0FZaJ5+1uR2OE3y86Q==}
     engines: {node: '>=16'}
     dependencies:
-      '@libp2p/interface-peer-discovery': 1.1.1
-      '@libp2p/interfaces': 3.3.1
-      '@waku/enr': 0.0.14
-      '@waku/utils': 0.0.8
+      '@waku/enr': 0.0.17
+      '@waku/utils': 0.0.11
       debug: 4.3.4(supports-color@8.1.1)
       dns-query: 0.11.2
       hi-base32: 0.5.1
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@waku/enr@0.0.14:
-    resolution: {integrity: sha512-oujSa7lVZoVEL2A/xA1UQqkktkeSL7I1ivt6hsMfK/3BbsQPt4d4LchY5QG7Vahrebv2BZ+/tvckhQ2mkF3azg==}
+  /@waku/enr@0.0.17:
+    resolution: {integrity: sha512-QNsHHbW9XqWliJ8/L0rQs3tYDcmcneHjM1M8ux4oZuYVV1xLtl+T3ah7koU6tFLpWg7EMsG5qi186GZCLPcnOQ==}
     engines: {node: '>=16'}
     dependencies:
       '@ethersproject/rlp': 5.7.0
       '@libp2p/crypto': 1.0.17
-      '@libp2p/peer-id': 2.0.3
-      '@multiformats/multiaddr': 12.1.3
+      '@libp2p/peer-id': 3.0.3
+      '@multiformats/multiaddr': 12.1.7
       '@noble/secp256k1': 1.7.1
-      '@waku/utils': 0.0.8
+      '@waku/utils': 0.0.11
       debug: 4.3.4(supports-color@8.1.1)
       js-sha3: 0.8.0
     transitivePeerDependencies:
@@ -2800,6 +2527,31 @@ packages:
     engines: {node: '>=16'}
     dev: true
 
+  /@waku/interfaces@0.0.18:
+    resolution: {integrity: sha512-esgXs8fZTth+7DSndnB92/YPOnpn0rD0E4GPu/yfQZbwSS+pPyfpk58iklgWterD/CelB487X4qy0ooe2uWrBg==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /@waku/peer-exchange@0.0.16(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13):
+    resolution: {integrity: sha512-Xcst5fQOEZsjHDS6ySTATJyFecJwLVvDYSClol/gWXxgAuMgiWVbcH8G6CzOWkq9Cu84y5JbhK+52xiNtfvl0g==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@libp2p/interfaces': 3.3.2
+      '@waku/core': 0.0.23(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13)
+      '@waku/enr': 0.0.17
+      '@waku/interfaces': 0.0.18
+      '@waku/proto': 0.0.5
+      '@waku/utils': 0.0.11
+      debug: 4.3.4(supports-color@8.1.1)
+      it-all: 3.0.3
+      it-length-prefixed: 9.0.1
+      it-pipe: 3.0.1
+    transitivePeerDependencies:
+      - '@multiformats/multiaddr'
+      - libp2p
+      - supports-color
+    dev: true
+
   /@waku/proto@0.0.5:
     resolution: {integrity: sha512-td0WKhUm+pcnpkbhuu5XV79ZcuM+f7b5swNIHHcqCaW5FaJeCtEhXsG8kNrt97kcDAHdr41lxFgQTRDlmAns4A==}
     engines: {node: '>=16'}
@@ -2807,37 +2559,39 @@ packages:
       protons-runtime: 5.0.0
     dev: true
 
-  /@waku/relay@0.0.3(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2):
-    resolution: {integrity: sha512-KDcfuOnTu/8HjNTwPXeVyd+qEIPZ7AXH0p4EwbfiucHbYWy7ahpljYz1fExwG7nKFsZ9uKtB7QGBBDy1ghKMCA==}
+  /@waku/relay@0.0.6(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13):
+    resolution: {integrity: sha512-PJGGBIfBlaBEroOI0kL0Gk45C+hieOU6h0/kHDIDDo2owly271NNy7OfMoWKsT6Lwf9e+PPGsZZLNtKivkN6Ig==}
     engines: {node: '>=16'}
     dependencies:
-      '@chainsafe/libp2p-gossipsub': 6.3.0
-      '@noble/hashes': 1.3.0
-      '@waku/core': 0.0.20(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2)
-      '@waku/interfaces': 0.0.15
+      '@chainsafe/libp2p-gossipsub': 10.1.0
+      '@noble/hashes': 1.3.2
+      '@waku/core': 0.0.23(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13)
+      '@waku/interfaces': 0.0.18
       '@waku/proto': 0.0.5
-      '@waku/utils': 0.0.8
+      '@waku/utils': 0.0.11
       chai: 4.3.7
       debug: 4.3.4(supports-color@8.1.1)
-      fast-check: 3.10.0
+      fast-check: 3.13.1
     transitivePeerDependencies:
       - '@multiformats/multiaddr'
       - libp2p
       - supports-color
     dev: true
 
-  /@waku/sdk@0.0.16(@multiformats/multiaddr@12.1.3):
-    resolution: {integrity: sha512-G9R+2rwOf8DE+lzLfcM5d5IICeRmktyfH4g77aWkgsBA5GvBJoMY5vnIS1j1tqJ+J4UfGp+CggHmHW+x9li1mA==}
+  /@waku/sdk@0.0.19(@multiformats/multiaddr@12.1.3):
+    resolution: {integrity: sha512-py9Xk4rOzhVm9vE7aRimHagfvKRQNzLs+otqS9ng4crUgf5ZKPvPsaA6/eV9FHQcWOT7EUpAy5UChh4kSjK2zQ==}
     engines: {node: '>=16'}
     dependencies:
-      '@chainsafe/libp2p-noise': 11.0.4
-      '@libp2p/mplex': 7.1.7
-      '@libp2p/websockets': 5.0.10
-      '@waku/core': 0.0.20(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2)
-      '@waku/dns-discovery': 0.0.14
-      '@waku/relay': 0.0.3(@multiformats/multiaddr@12.1.3)(libp2p@0.42.2)
-      '@waku/utils': 0.0.8
-      libp2p: 0.42.2
+      '@chainsafe/libp2p-noise': 13.0.1
+      '@libp2p/mplex': 9.0.8
+      '@libp2p/websockets': 7.0.9
+      '@waku/core': 0.0.23(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13)
+      '@waku/dns-discovery': 0.0.17
+      '@waku/interfaces': 0.0.18
+      '@waku/peer-exchange': 0.0.16(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13)
+      '@waku/relay': 0.0.6(@multiformats/multiaddr@12.1.3)(libp2p@0.46.13)
+      '@waku/utils': 0.0.11
+      libp2p: 0.46.13
     transitivePeerDependencies:
       - '@multiformats/multiaddr'
       - bufferutil
@@ -2845,12 +2599,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@waku/utils@0.0.8:
-    resolution: {integrity: sha512-pMs06f+P+jBq8v4Hyek7VTkCB0Suxc+baXqNfqTdM7xqzmwnCjfi1q9ummCln17Q3+6lVsbwHzUfikGTyoMeow==}
+  /@waku/utils@0.0.11:
+    resolution: {integrity: sha512-AG/S9vxqqxQUO9dlfi5Apv5o364dIzg3cLm32qstqQDSWw3QGhOSRLg+MBxdFrfmELCI3O1zdMoGdLRaZIwr8Q==}
     engines: {node: '>=16'}
     dependencies:
+      '@waku/interfaces': 0.0.18
       debug: 4.3.4(supports-color@8.1.1)
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2860,13 +2615,6 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
-    dev: true
-
-  /abortable-iterator@4.0.3:
-    resolution: {integrity: sha512-GJ5fyS9O0hK/TMf+weR+WMEwSEBWVuStHqHmUYWbfHPULyVf7QdUnAvh41+1cUWtHVf0Z/qtQynidxz4ZFDPOg==}
-    dependencies:
-      get-iterator: 2.0.0
-      it-stream-types: 1.0.5
     dev: true
 
   /abortable-iterator@5.0.1:
@@ -3357,6 +3105,7 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -3501,22 +3250,22 @@ packages:
       multiformats: 11.0.2
     dev: true
 
-  /datastore-core@8.0.4:
-    resolution: {integrity: sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /datastore-core@9.2.3:
+    resolution: {integrity: sha512-jcvrVDt+jp7lUp2WhMXXgX/hoi3VcJebN+z/ZXbIRKOVfNOF4bl8cvr7sQ1y9qITikgC2coXFYd79Wzt/n13ZQ==}
     dependencies:
-      '@libp2p/logger': 2.0.7
+      '@libp2p/logger': 3.0.3
       err-code: 3.0.1
-      interface-datastore: 7.0.4
-      it-all: 2.0.1
-      it-drain: 2.0.1
-      it-filter: 2.0.2
-      it-map: 2.0.1
-      it-merge: 2.0.1
-      it-pipe: 2.0.5
-      it-pushable: 3.1.3
-      it-take: 2.0.1
-      uint8arrays: 4.0.3
+      interface-store: 5.1.0
+      it-all: 3.0.2
+      it-drain: 3.0.3
+      it-filter: 3.0.3
+      it-map: 3.0.4
+      it-merge: 3.0.1
+      it-pipe: 3.0.1
+      it-pushable: 3.2.1
+      it-sort: 3.0.3
+      it-take: 3.0.3
+      uint8arrays: 4.0.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3564,22 +3313,28 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /default-gateway@6.0.3:
-    resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
-    engines: {node: '>= 10'}
+  /default-gateway@7.2.2:
+    resolution: {integrity: sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==}
+    engines: {node: '>= 16'}
     dependencies:
-      execa: 5.1.1
+      execa: 7.2.0
     dev: true
 
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+    requiresBuild: true
     dependencies:
       clone: 1.0.4
     dev: true
     optional: true
 
-  /denque@1.5.1:
-    resolution: {integrity: sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==}
+  /delay@6.0.0:
+    resolution: {integrity: sha512-2NJozoOHQ4NuZuVIr5CWd0iiLVIRSDepakaovIN+9eIDHEhdCAEvSy2cuf1DCrPPQLvHmbqTHODlhHg8UCy4zw==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
     dev: true
 
@@ -4077,23 +3832,23 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
       merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
       signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
+      strip-final-newline: 3.0.0
     dev: true
 
-  /fast-check@3.10.0:
-    resolution: {integrity: sha512-I2FldZwnCbcY6iL+H0rp9m4D+O3PotuFu9FasWjMCzUedYHMP89/37JbSt6/n7Yq/IZmJDW0B2h30sPYdzrfzw==}
+  /fast-check@3.13.1:
+    resolution: {integrity: sha512-Xp00tFuWd83i8rbG/4wU54qU+yINjQha7bXH2N4ARNTkyOimzHtUBJ5+htpdXk7RMaCOD/j2jxSjEt9u9ZPNeQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       pure-rand: 6.0.2
@@ -4482,10 +4237,6 @@ packages:
       minimalistic-assert: 1.0.1
     dev: true
 
-  /hashlru@2.3.0:
-    resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
-    dev: true
-
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -4532,9 +4283,9 @@ packages:
       - supports-color
     dev: true
 
-  /human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
     dev: true
 
   /iconv-lite@0.4.24:
@@ -4799,6 +4550,11 @@ packages:
     resolution: {integrity: sha512-SEsepLbdWFb13B6U0tt6dYcUM0iK/U7XOC43N70Z4Qb88WpNtp+ospyNI9ddpqncs7Z7brAEsVBTQpaqSNntIw==}
     dev: true
 
+  /is-network-error@1.0.0:
+    resolution: {integrity: sha512-P3fxi10Aji2FZmHTrMPSNFbNC6nnp4U5juPAIjXPHkUNubi4+qK7vvdsaNpAUwXslhYm9oyjEYTxs1xd/+Ph0w==}
+    engines: {node: '>=16'}
+    dev: true
+
   /is-number@4.0.0:
     resolution: {integrity: sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==}
     engines: {node: '>=0.10.0'}
@@ -4825,9 +4581,9 @@ packages:
       '@types/estree': 1.0.1
     dev: true
 
-  /is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /is-unicode-supported@0.1.0:
@@ -4858,23 +4614,33 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /it-batched-bytes@1.0.1:
-    resolution: {integrity: sha512-ptBiZ0Mh3kJYySpG0pCS7JgvWhaAW1fGfKDVFtNIuNTA+bpSlXINvD5H3b14ZlJbnJFzFzRSCSZ10E1nH4z/WQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-all@3.0.3:
+    resolution: {integrity: sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A==}
+    dev: true
+
+  /it-batched-bytes@2.0.4:
+    resolution: {integrity: sha512-n4V19XACvFG+b8lCkuvidYvwpyz3++DAolqZGI+9AcDvIPMAhVwwtFCe9SiDIz45OzQnnNYwBgBxbIinHPgraA==}
     dependencies:
-      it-stream-types: 1.0.5
       p-defer: 4.0.0
       uint8arraylist: 2.4.3
     dev: true
 
-  /it-drain@2.0.1:
-    resolution: {integrity: sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-byte-stream@1.0.1:
+    resolution: {integrity: sha512-Nu1/y8ObmrEmpHfWBHrWKtla9xwTdnMceB7v1z7tM+H84VP5Ou59wyFiJHsyvuIETLfKFY+TfhEbOJy24FRGjQ==}
+    dependencies:
+      it-pushable: 3.2.1
+      it-stream-types: 2.0.1
+      uint8arraylist: 2.4.3
     dev: true
 
-  /it-filter@2.0.2:
-    resolution: {integrity: sha512-gocw1F3siqupegsOzZ78rAc9C+sYlQbI2af/TmzgdrR613MyEJHbvfwBf12XRekGG907kqXSOGKPlxzJa6XV1Q==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-drain@3.0.3:
+    resolution: {integrity: sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA==}
+    dev: true
+
+  /it-filter@3.0.3:
+    resolution: {integrity: sha512-2zXUrJuuV6QHM21ahc8NqVUUxkLMVDWXBoUBcj9GCQLQez2OXmddTHN0r0F5B+TkNTpeL618yIgXi1HNPJOxow==}
+    dependencies:
+      it-peekable: 3.0.2
     dev: true
 
   /it-first@2.0.1:
@@ -4884,11 +4650,6 @@ packages:
 
   /it-first@3.0.2:
     resolution: {integrity: sha512-QPLAM2BOkait/o6W25HvP0XTEv+Os3Ce4wET//ADNaPv+WYAHWfQwJuMu5FB8X066hA1F7LEMnULvTpE7/4yQw==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dev: true
-
-  /it-foreach@1.0.1:
-    resolution: {integrity: sha512-eaVFhKxU+uwPs7+DKYxjuL6pj6c50/MBlAH+XPMgPWRRVIChVoyEIsdUQkkC0Ad6oTUmJbKRTnJxEY6o2aIs7A==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
@@ -4903,7 +4664,7 @@ packages:
     resolution: {integrity: sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
-      it-pushable: 3.1.3
+      it-pushable: 3.2.1
       it-reader: 6.0.4
       it-stream-types: 2.0.1
       p-defer: 4.0.0
@@ -4915,15 +4676,14 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /it-length-prefixed@8.0.4:
-    resolution: {integrity: sha512-5OJ1lxH+IaqJB7lxe8IAIwt9UfSfsmjKJoAI/RO9djYoBDt1Jfy9PeVHUmOfqhqyu/4kJvWBFAJUaG1HhLQ12A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-length-prefixed-stream@1.0.2:
+    resolution: {integrity: sha512-gWevodoctgwWUaRJN9t+xEs1H1GQNYAjLCR7FO50fon9Ph4OJGgrxPKTc26QXKrC/cIQZLkHYClphUw0wl1k2A==}
     dependencies:
-      err-code: 3.0.1
-      it-stream-types: 1.0.5
-      uint8-varint: 1.0.6
+      it-byte-stream: 1.0.1
+      it-length-prefixed: 9.0.1
+      it-stream-types: 2.0.1
+      uint8-varint: 2.0.1
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
     dev: true
 
   /it-length-prefixed@9.0.1:
@@ -4934,7 +4694,7 @@ packages:
       it-stream-types: 2.0.1
       uint8-varint: 1.0.6
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
     dev: true
 
   /it-map@2.0.1:
@@ -4942,18 +4702,17 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /it-merge@2.0.1:
-    resolution: {integrity: sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-map@3.0.4:
+    resolution: {integrity: sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==}
     dependencies:
-      it-pushable: 3.1.3
+      it-peekable: 3.0.2
     dev: true
 
   /it-merge@3.0.1:
     resolution: {integrity: sha512-I6hjU1ABO+k3xY1H6JtCSDXvUME88pxIXSgKeT4WI5rPYbQzpr98ldacVuG95WbjaJxKl6Qot6lUdxduLBQPHA==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
-      it-pushable: 3.1.3
+      it-pushable: 3.2.1
     dev: true
 
   /it-pair@2.0.6:
@@ -4964,17 +4723,10 @@ packages:
       p-defer: 4.0.0
     dev: true
 
-  /it-pb-stream@3.2.1:
-    resolution: {integrity: sha512-vKE04Zv5MUcwxPNE9bIEfYK3rd/Klj5ORGD1D8Bn5f0mbCLGfouSrqZP1Jntg2osqQg4BN5dKKS2BbfwyGUI3Q==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-parallel@3.0.4:
+    resolution: {integrity: sha512-fuA+SysGxbZc+Yl7EUvzQqZ8bNYQghZ0Mq9zA+fxMQ5eQYzatNg6oJk1y1PvPvNqLgKJMzEInpRO6PbLC3hGAg==}
     dependencies:
-      err-code: 3.0.1
-      it-length-prefixed: 9.0.1
-      it-pushable: 3.1.3
-      it-stream-types: 1.0.5
-      protons-runtime: 5.0.0
-      uint8-varint: 1.0.6
-      uint8arraylist: 2.4.3
+      p-defer: 4.0.0
     dev: true
 
   /it-peekable@2.0.1:
@@ -4982,13 +4734,8 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /it-pipe@2.0.5:
-    resolution: {integrity: sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      it-merge: 2.0.1
-      it-pushable: 3.1.3
-      it-stream-types: 1.0.5
+  /it-peekable@3.0.2:
+    resolution: {integrity: sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA==}
     dev: true
 
   /it-pipe@3.0.1:
@@ -4996,13 +4743,29 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       it-merge: 3.0.1
-      it-pushable: 3.1.3
+      it-pushable: 3.2.1
       it-stream-types: 2.0.1
+    dev: true
+
+  /it-protobuf-stream@1.0.2:
+    resolution: {integrity: sha512-2lESJIeZS2ZlYJc/1SKs6LL4Y83rCCvZv750xV1e4uuP9114yNkw2MhIGCtSReg+qNWCvzGqOwjQbKV0LFE6wQ==}
+    dependencies:
+      it-length-prefixed-stream: 1.0.2
+      it-stream-types: 2.0.1
+      protons-runtime: 5.0.0
+      uint8arraylist: 2.4.3
     dev: true
 
   /it-pushable@3.1.3:
     resolution: {integrity: sha512-f50iQ85HISS6DaWCyrqf9QJ6G/kQtKIMf9xZkgZgyOvxEQDfn8OfYcLXXquCqgoLboxQtAW1ZFZyFIAsLHDtJw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: true
+
+  /it-pushable@3.2.1:
+    resolution: {integrity: sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dependencies:
+      p-defer: 4.0.0
     dev: true
 
   /it-reader@6.0.4:
@@ -5013,11 +4776,10 @@ packages:
       uint8arraylist: 2.4.3
     dev: true
 
-  /it-sort@2.0.1:
-    resolution: {integrity: sha512-9f4jKOTHfxc/FJpg/wwuQ+j+88i+sfNGKsu2HukAKymm71/XDnBFtOAOzaimko3YIhmn/ERwnfEKrsYLykxw9A==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-sort@3.0.3:
+    resolution: {integrity: sha512-9BuQc5Y2fmBUNhevQBUDHfItrQmzWoZcnzydJl91V6na6M+RkbNj71UtCPPNIpOt/SQG+va0pe1wMQJ9lP2Oew==}
     dependencies:
-      it-all: 2.0.1
+      it-all: 3.0.2
     dev: true
 
   /it-stream-types@1.0.5:
@@ -5030,9 +4792,8 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /it-take@2.0.1:
-    resolution: {integrity: sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /it-take@3.0.3:
+    resolution: {integrity: sha512-Ay5SXEyrBKD0tO8PQif2QjrStImIsLIg0F50Uu4EeXOw8C9DfVIGfsGL3X9s65F2I9skDp9mLgBzl71IToMxNw==}
     dev: true
 
   /it-to-stream@1.0.0:
@@ -5046,14 +4807,15 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  /it-ws@5.0.6:
-    resolution: {integrity: sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==}
+  /it-ws@6.0.5:
+    resolution: {integrity: sha512-xp7tF4fHgx8+vN3Qy/8wGiWUKbC9E1U1g9PwtlbdxD7pY4zld71ZyWZVFHLxnxxg14T9mVNK5uO7U9HK11VQ5g==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
+      '@types/ws': 8.5.6
       event-iterator: 2.0.0
       iso-url: 1.2.1
-      it-stream-types: 1.0.5
-      uint8arrays: 4.0.3
+      it-stream-types: 2.0.1
+      uint8arrays: 4.0.6
       ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
@@ -5092,10 +4854,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
-
-  /jsbn@1.1.0:
-    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
     dev: true
 
   /json-parse-even-better-errors@3.0.0:
@@ -5201,76 +4959,53 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /libp2p@0.42.2:
-    resolution: {integrity: sha512-arTOCJEEmAFw5HjlXdULVAFs7Y/dWZmgX/qN4SzuxtSkB0pa+fqn/DIbIfpBi2BuY+QozvnARPF1xJtSdqfqJQ==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /libp2p@0.46.13:
+    resolution: {integrity: sha512-WcHWvqXasbJYINifmyfChK4gaTRF+TPthTu0h9OQz1Hvod4cXBhlBwqpeKkUD1Y3+6jb+fHS/w3iV0X2oaLfOw==}
     dependencies:
-      '@achingbrain/nat-port-mapper': 1.0.8
-      '@libp2p/crypto': 1.0.17
-      '@libp2p/interface-address-manager': 2.0.5
-      '@libp2p/interface-connection': 3.1.1
-      '@libp2p/interface-connection-encrypter': 3.0.6
-      '@libp2p/interface-connection-manager': 1.5.0
-      '@libp2p/interface-content-routing': 2.1.1
-      '@libp2p/interface-dht': 2.0.3
-      '@libp2p/interface-libp2p': 1.3.3
-      '@libp2p/interface-metrics': 4.0.8
-      '@libp2p/interface-peer-discovery': 1.1.1
-      '@libp2p/interface-peer-id': 2.0.1
-      '@libp2p/interface-peer-info': 1.0.9
-      '@libp2p/interface-peer-routing': 1.1.1
-      '@libp2p/interface-peer-store': 1.2.9
-      '@libp2p/interface-pubsub': 3.0.7
-      '@libp2p/interface-registrar': 2.0.12
-      '@libp2p/interface-stream-muxer': 3.0.6
-      '@libp2p/interface-transport': 2.1.3
-      '@libp2p/interfaces': 3.3.1
-      '@libp2p/logger': 2.0.7
-      '@libp2p/multistream-select': 3.1.8
-      '@libp2p/peer-collections': 3.0.1
-      '@libp2p/peer-id': 2.0.3
-      '@libp2p/peer-id-factory': 2.0.3
-      '@libp2p/peer-record': 5.0.3
-      '@libp2p/peer-store': 6.0.4
-      '@libp2p/tracked-map': 3.0.2
-      '@libp2p/utils': 3.0.11
-      '@multiformats/mafmt': 11.1.2
-      '@multiformats/multiaddr': 11.6.1
-      abortable-iterator: 4.0.3
-      any-signal: 3.0.1
-      datastore-core: 8.0.4
-      err-code: 3.0.1
+      '@achingbrain/nat-port-mapper': 1.0.11
+      '@libp2p/crypto': 2.0.5
+      '@libp2p/interface': 0.1.3
+      '@libp2p/interface-internal': 0.1.6
+      '@libp2p/keychain': 3.0.5
+      '@libp2p/logger': 3.0.3
+      '@libp2p/multistream-select': 4.0.3
+      '@libp2p/peer-collections': 4.0.5
+      '@libp2p/peer-id': 3.0.3
+      '@libp2p/peer-id-factory': 3.0.5
+      '@libp2p/peer-record': 6.0.6
+      '@libp2p/peer-store': 9.0.6
+      '@libp2p/utils': 4.0.4
+      '@multiformats/mafmt': 12.1.3
+      '@multiformats/multiaddr': 12.1.7
+      '@multiformats/multiaddr-matcher': 1.0.2
+      any-signal: 4.1.1
+      datastore-core: 9.2.3
+      delay: 6.0.0
       events: 3.3.0
-      hashlru: 2.3.0
-      interface-datastore: 7.0.4
-      it-all: 2.0.1
-      it-drain: 2.0.1
-      it-filter: 2.0.2
-      it-first: 2.0.1
-      it-foreach: 1.0.1
+      interface-datastore: 8.2.0
+      it-all: 3.0.2
+      it-drain: 3.0.3
+      it-filter: 3.0.3
+      it-first: 3.0.2
       it-handshake: 4.1.3
-      it-length-prefixed: 8.0.4
-      it-map: 2.0.1
-      it-merge: 2.0.1
+      it-length-prefixed: 9.0.1
+      it-map: 3.0.4
+      it-merge: 3.0.1
       it-pair: 2.0.6
-      it-pipe: 2.0.5
-      it-sort: 2.0.1
-      it-stream-types: 1.0.5
+      it-parallel: 3.0.4
+      it-pipe: 3.0.1
+      it-protobuf-stream: 1.0.2
+      it-stream-types: 2.0.1
       merge-options: 3.0.4
-      multiformats: 11.0.2
-      node-forge: 1.3.1
-      p-fifo: 1.0.0
-      p-retry: 5.1.2
-      p-settle: 5.1.0
+      multiformats: 12.1.2
+      p-defer: 4.0.0
+      p-queue: 7.3.4
+      p-retry: 6.1.0
       private-ip: 3.0.0
-      protons-runtime: 4.0.2
-      rate-limiter-flexible: 2.4.1
-      retimer: 3.0.0
-      sanitize-filename: 1.6.3
-      set-delayed-interval: 1.0.0
-      timeout-abort-controller: 3.0.0
+      protons-runtime: 5.0.0
+      rate-limiter-flexible: 3.0.0
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
       wherearewe: 2.0.1
       xsalsa20: 1.2.0
     transitivePeerDependencies:
@@ -5335,10 +5070,6 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    dev: true
-
-  /long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
     dev: true
 
   /long@5.2.3:
@@ -5474,9 +5205,9 @@ packages:
     hasBin: true
     dev: true
 
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
     dev: true
 
   /min-indent@1.0.1:
@@ -5615,6 +5346,11 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dev: true
 
+  /multiformats@12.1.2:
+    resolution: {integrity: sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: true
+
   /nanoid@3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5702,11 +5438,11 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
-  /npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
+  /npm-run-path@5.1.0:
+    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      path-key: 3.1.1
+      path-key: 4.0.0
     dev: true
 
   /object-pairs@0.1.0:
@@ -5733,11 +5469,11 @@ packages:
       wrappy: 1.0.2
     dev: true
 
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
     dependencies:
-      mimic-fn: 2.1.0
+      mimic-fn: 4.0.0
     dev: true
 
   /optionator@0.9.3:
@@ -5831,25 +5567,13 @@ packages:
       p-timeout: 5.1.0
     dev: true
 
-  /p-reflect@3.1.0:
-    resolution: {integrity: sha512-3sG3UlpisPSaX+o7u2q01hIQmrpkvdl5GSO1ZwL7pfc5kHB2bPF0eFNCfYTrW1/LTUdgmPwBAvmT0Zr8eSmaAQ==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /p-retry@5.1.2:
-    resolution: {integrity: sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /p-retry@6.1.0:
+    resolution: {integrity: sha512-fJLEQ2KqYBJRuaA/8cKMnqhulqNM+bpcjYtXNex2t3mOXKRYPitAJt9NacSf8XAFzcYahSAbKpobiWDSqHSh2g==}
+    engines: {node: '>=16.17'}
     dependencies:
-      '@types/retry': 0.12.1
+      '@types/retry': 0.12.2
+      is-network-error: 1.0.0
       retry: 0.13.1
-    dev: true
-
-  /p-settle@5.1.0:
-    resolution: {integrity: sha512-ujR6UFfh09ziOKyC5aaJak5ZclsjlLw57SYtFZg6yllMofyygnaibQRZ4jf6QPWqoOCGUXyb1cxUKELeAyKO7g==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      p-limit: 4.0.0
-      p-reflect: 3.1.0
     dev: true
 
   /p-timeout@5.1.0:
@@ -5901,6 +5625,11 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /path-parse@1.0.7:
@@ -6024,26 +5753,6 @@ packages:
       netmask: 2.0.2
     dev: true
 
-  /protobufjs@6.11.3:
-    resolution: {integrity: sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
-      '@types/node': 20.5.4
-      long: 4.0.0
-    dev: true
-
   /protobufjs@7.2.3:
     resolution: {integrity: sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==}
     engines: {node: '>=12.0.0'}
@@ -6063,12 +5772,23 @@ packages:
       long: 5.2.3
     dev: true
 
-  /protons-runtime@4.0.2:
-    resolution: {integrity: sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+  /protobufjs@7.2.5:
+    resolution: {integrity: sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
     dependencies:
-      protobufjs: 7.2.3
-      uint8arraylist: 2.4.3
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.5.4
+      long: 5.2.3
     dev: true
 
   /protons-runtime@5.0.0:
@@ -6092,14 +5812,18 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /race-signal@1.0.1:
+    resolution: {integrity: sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw==}
+    dev: true
+
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
       safe-buffer: 5.2.1
     dev: true
 
-  /rate-limiter-flexible@2.4.1:
-    resolution: {integrity: sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g==}
+  /rate-limiter-flexible@3.0.0:
+    resolution: {integrity: sha512-janAJkWxWxmLka0hV+XvCTo0M8keeSeOuz8ZL33cTXrkS4ek9mQ2VJm9ri7fm03oTVth19Sfqb1ijCmo7K/vAg==}
     dev: true
 
   /raw-body@2.5.2:
@@ -6342,10 +6066,6 @@ packages:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
     dev: true
 
-  /set-delayed-interval@1.0.0:
-    resolution: {integrity: sha512-29fhAwuZlLcuBnW/EwxvLcg2D3ELX+VBDNhnavs3YYkab72qmrcSeQNVdzl8EcPPahGQXhBM6MKdPLCQGMDakw==}
-    dev: true
-
   /setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
     dev: true
@@ -6455,10 +6175,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /sprintf-js@1.1.2:
-    resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
-    dev: true
-
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
@@ -6536,9 +6252,9 @@ packages:
       ansi-regex: 6.0.1
     dev: true
 
-  /strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
     dev: true
 
   /strip-hex-prefix@1.0.0:
@@ -6921,7 +6637,14 @@ packages:
       byte-access: 1.0.1
       longbits: 1.1.0
       uint8arraylist: 2.4.3
-      uint8arrays: 4.0.3
+      uint8arrays: 4.0.6
+    dev: true
+
+  /uint8-varint@2.0.1:
+    resolution: {integrity: sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==}
+    dependencies:
+      uint8arraylist: 2.4.3
+      uint8arrays: 4.0.6
     dev: true
 
   /uint8arraylist@2.4.3:
@@ -6936,6 +6659,12 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       multiformats: 11.0.2
+    dev: true
+
+  /uint8arrays@4.0.6:
+    resolution: {integrity: sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==}
+    dependencies:
+      multiformats: 12.1.2
     dev: true
 
   /undici@5.20.0:
@@ -7277,6 +7006,14 @@ packages:
 
   /xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: true
+
+  /xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
     dependencies:
       sax: 1.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ devDependencies:
     specifier: ^0.4.0
     version: 0.4.0
   '@waku/interfaces':
-    specifier: ^0.0.15
-    version: 0.0.15
+    specifier: ^0.0.18
+    version: 0.0.18
   '@waku/sdk':
     specifier: ^0.0.19
     version: 0.0.19(@multiformats/multiaddr@12.1.3)
@@ -2520,11 +2520,6 @@ packages:
       js-sha3: 0.8.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@waku/interfaces@0.0.15:
-    resolution: {integrity: sha512-l8MDtMtA51nWeeU36lZV07JWMLHmnn7Dm93ihS2lgqWACbhzwOEDZ3alox4T8Um7A3RmnK/WZ5U2Cprs3ukt8w==}
-    engines: {node: '>=16'}
     dev: true
 
   /@waku/interfaces@0.0.18:

--- a/src/lib/adapters/waku/safe-waku.ts
+++ b/src/lib/adapters/waku/safe-waku.ts
@@ -117,7 +117,7 @@ export class SafeWaku {
 			} finally {
 				if (error) {
 					this.errors.numSendError++
-					this.log(`⁉️  Error: ${error}`)
+					this.log(`⁉️  Error: ${error}`, { error })
 					this.log(`🕓 Waiting ${timeout} milliseconds...`)
 					await sleep(timeout)
 					if (timeout < 120_000) {

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -28,8 +28,8 @@ const peers = [
 	// '/dns4/waku.de.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmRgjA134DcoyK8r44pKWJQ69C7McLSWtRgxUVwkKAsbGx',
 
 	'/dns4/go-waku.gra.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmMafTFmwN9xat1jw7eHnwZJruQiezttwfRaeSgY5hkwe5',
-	// '/dns4/go-waku.de.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmTwF1VMGkNLXJDj7jLNLMeFwZt8jP8qKS1uojQSCiHib6',
-	// '/dns4/go-waku.bhs.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAm2RwLYewyx3UWZgKT7SQPjASF8AYE3WCyWiM9xupZNCmW'
+	'/dns4/go-waku.de.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmTwF1VMGkNLXJDj7jLNLMeFwZt8jP8qKS1uojQSCiHib6',
+	'/dns4/go-waku.bhs.nomad.apyos.dev/tcp/443/wss/p2p/16Uiu2HAm2RwLYewyx3UWZgKT7SQPjASF8AYE3WCyWiM9xupZNCmW',
 
 	// '/dns4/go-waku.srv02.apyos.dev/tcp/443/wss/p2p/16Uiu2HAmPwoBY7YzjGAkHDzd93wX1rXks7MRMCX7m1Jr2b8jSSwQ',
 ]
@@ -51,7 +51,7 @@ export interface ConnectWakuOptions {
 }
 
 export async function connectWaku(options?: ConnectWakuOptions) {
-	const waku = await createLightNode()
+	const waku = await createLightNode({ pingKeepAlive: 60 })
 
 	waku.libp2p.addEventListener('peer:disconnect', () => {
 		if (options?.onDisconnect && waku.libp2p.getConnections().length === 0) {

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -100,7 +100,9 @@ export async function storeDocument(
 	const payload = utf8ToBytes(json)
 
 	const sendResult = await waku.lightPush.send(encoder, { payload })
-	return sendResult.errors
+	if (sendResult.errors && sendResult.errors.length > 0) {
+		return sendResult.errors
+	}
 }
 
 export async function readStore(
@@ -126,5 +128,7 @@ export async function sendMessage(waku: LightNode, id: string, message: unknown)
 	const encoder = createEncoder({ contentTopic })
 
 	const sendResult = await waku.lightPush.send(encoder, { payload })
-	return sendResult.errors
+	if (sendResult.errors && sendResult.errors.length > 0) {
+		return sendResult.errors
+	}
 }

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -100,7 +100,7 @@ export async function storeDocument(
 	const payload = utf8ToBytes(json)
 
 	const sendResult = await waku.lightPush.send(encoder, { payload })
-	return sendResult.error
+	return sendResult.errors
 }
 
 export async function readStore(
@@ -126,5 +126,5 @@ export async function sendMessage(waku: LightNode, id: string, message: unknown)
 	const encoder = createEncoder({ contentTopic })
 
 	const sendResult = await waku.lightPush.send(encoder, { payload })
-	return sendResult.error
+	return sendResult.errors
 }


### PR DESCRIPTION
Changes in this PR:
- Connect to a cluster using 3 go-waku nodes
- Add `pingKeepAlive` to make connectivity more stable
- Use latest version of `js-waku` and interfaces
- Update the error handling to the latest version

Also closes #375 and closes #373