### PR TITLE
feat: make invite more resilient

### DIFF
--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -276,9 +276,11 @@ export default class WakuAdapter implements Adapter {
 
 	async startChat(address: string, peerAddress: string): Promise<string> {
 		const chatId = peerAddress
-		const user = await this.storageProfileToUser(chatId)
+		let user = await this.storageProfileToUser(chatId)
 		if (!user) {
-			throw 'invalid user'
+			user = {
+				address: peerAddress,
+			}
 		}
 
 		const joined = true


### PR DESCRIPTION
Before this change if the user profile was not found then an exception was thrown silently and it was not possible to join to the chat from an invite link. This may happen sometimes when nodes are changed or the data is old and cannot be found on the waku network.

With this PR it is possible to add the user as a contact, although their names will be `undefined`. However as soon as they change their profile and the page is reloaded then the correct profile will be shown.