### PR TITLE
fix: undefined name

### DIFF
--- a/src/lib/utils/user.ts
+++ b/src/lib/utils/user.ts
@@ -1,0 +1,5 @@
+import type { User } from '$lib/types'
+
+export function userDisplayName(user?: User): string {
+	return user?.name ?? user?.address.slice(0, 20) + '...' ?? ''
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,6 +22,7 @@
 	import Layout from '$lib/components/layout.svelte'
 	import Events from '$lib/components/icons/events.svelte'
 	import { formatTimestamp } from '$lib/utils/format'
+	import { userDisplayName } from '$lib/utils/user'
 
 	$: orderedChats = Array.from($chats.chats)
 		.map(([, chat]) => chat)
@@ -175,7 +176,7 @@
 														<Events />
 													{:else}
 														<span class="truncate">
-															{otherUser?.name}
+															{userDisplayName(otherUser)}
 														</span>
 													{/if}
 													{#if !chat.joined}

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -32,6 +32,7 @@
 		formatTimestampTime,
 	} from '$lib/utils/format'
 	import ChatDateBadge from '$lib/components/chat-date-badge.svelte'
+	import { userDisplayName } from '$lib/utils/user'
 
 	let div: HTMLElement
 	let autoscroll = true
@@ -101,7 +102,7 @@
 					</Button>
 					<svelte:fragment slot="chat">
 						<Avatar picture={otherUser?.avatar} seed={otherUser?.address} />
-						{otherUser?.name}
+						{userDisplayName(otherUser)}
 					</svelte:fragment>
 				</Header>
 			</svelte:fragment>

--- a/src/routes/group/chat/[id]/edit/+page.svelte
+++ b/src/routes/group/chat/[id]/edit/+page.svelte
@@ -30,6 +30,7 @@
 	import { walletStore } from '$lib/stores/wallet'
 	import ROUTES from '$lib/routes'
 	import Loading from '$lib/components/loading.svelte'
+	import { userDisplayName } from '$lib/utils/user'
 
 	$: chatId = $page.params.id
 	$: groupChat = $chats.chats.get(chatId)
@@ -176,7 +177,7 @@
 											{#if isMe}
 												<span class="username text-italic"> You </span>
 											{:else}
-												<span class="username">{user.name}</span>
+												<span class="username">{userDisplayName(user)}</span>
 											{/if}
 										</div>
 									</div>


### PR DESCRIPTION
This PR fixes undefined names in 3 places:
- chat list
- chat view header
- group chat edit page

First I tried to truncate the address with CSS, but it required different solutions in each pages, so eventually just settled on truncating in the `userDisplayName` function.

Before:
![Screenshot from 2023-10-10 17-30-47](https://github.com/logos-innovation-lab/waku-objects-playground/assets/230163/e32ac8d5-4e65-447e-a770-7b070241f690)

After:
![Screenshot from 2023-10-10 17-48-11](https://github.com/logos-innovation-lab/waku-objects-playground/assets/230163/ec5c11be-a407-45de-aabe-f78e87ec1d47)
