### PR TITLE
feat: extract splitterFactory address to the object and expose chain ID

### DIFF
--- a/src/lib/adapters/transaction.ts
+++ b/src/lib/adapters/transaction.ts
@@ -18,17 +18,16 @@ interface BlockchainExplorer {
 
 interface BlockchainNetwork {
 	name: string
+	chainId: bigint
 	provider: string
 	explorer?: BlockchainExplorer
 	nativeToken: Token
 	tokens?: Token[]
-	objects: {
-		splitterFactory: string
-	}
 }
 
 const localBlockchain: BlockchainNetwork = {
 	name: 'Local testnet',
+	chainId: 31337n,
 	provider: 'http://127.0.0.1:8545',
 	nativeToken: {
 		name: 'Test Ether',
@@ -36,13 +35,11 @@ const localBlockchain: BlockchainNetwork = {
 		decimals: 18,
 		image: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png',
 	},
-	objects: {
-		splitterFactory: '0x0',
-	},
 }
 
 const chiadoBlockchain: BlockchainNetwork = {
 	name: 'Chiado testnet',
+	chainId: 10200n,
 	provider: 'https://rpc.chiado.apyos.dev/',
 	explorer: {
 		name: 'Blockscout',
@@ -63,13 +60,11 @@ const chiadoBlockchain: BlockchainNetwork = {
 			address: '0x19C653Da7c37c66208fbfbE8908A5051B57b4C70',
 		},
 	],
-	objects: {
-		splitterFactory: '0x941DDB22a33FC753d3E7b82cc34c47Ee605e60a3',
-	},
 }
 
 const gnosisBlockchain: BlockchainNetwork = {
 	name: 'Gnosis',
+	chainId: 100n,
 	provider: 'https://gnosis-erigon.apyos.dev/',
 	explorer: {
 		name: 'Blockscout',
@@ -90,9 +85,6 @@ const gnosisBlockchain: BlockchainNetwork = {
 			address: '0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb',
 		},
 	],
-	objects: {
-		splitterFactory: '0x99873C280c0c4A5460AB781e4bcD06f6B5f35717',
-	},
 }
 
 function getBlockchainNetwork(): BlockchainNetwork {
@@ -116,6 +108,12 @@ export function getProvider(): Provider {
 	const providerUrl = defaultBlockchainNetwork.provider
 	const provider = new JsonRpcProvider(providerUrl)
 	return provider
+}
+
+export async function getChainId(): Promise<bigint> {
+	const provider = getProvider()
+	const { chainId } = await provider.getNetwork()
+	return chainId
 }
 
 export async function sendTransaction(

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -36,6 +36,7 @@ import { walletStore } from '$lib/stores/wallet'
 import { SafeWaku } from './safe-waku'
 import type { TokenAmount } from '$lib/objects/schemas'
 import { DEFAULT_FIAT_SYMBOL, exchangeStore } from '$lib/stores/exchangeRates'
+import { balanceStore } from '$lib/stores/balances'
 
 const MAX_MESSAGES = 100
 
@@ -148,6 +149,7 @@ async function executeOnDataMessage(
 			chat?.name ?? users.find((u) => u.address !== myProfile.address)?.name ?? 'Unknown'
 		const args: WakuObjectArgs = {
 			...context,
+			chainId: defaultBlockchainNetwork.chainId,
 			chatName,
 			chatId,
 			objectId: dataMessage.objectId,
@@ -156,7 +158,7 @@ async function executeOnDataMessage(
 			profile: myProfile,
 			exchangeRates: get(exchangeStore).exchange,
 			fiatSymbol: DEFAULT_FIAT_SYMBOL,
-			tokens: defaultBlockchainNetwork.tokens?.map((t) => ({ ...t, amount: 0n })) || [],
+			tokens: get(balanceStore).balances,
 		}
 		await descriptor.onMessage(dataMessage, args)
 	}

--- a/src/lib/objects/chat.svelte
+++ b/src/lib/objects/chat.svelte
@@ -14,6 +14,7 @@
 	import routes from '$lib/routes'
 	import { chats } from '$lib/stores/chat'
 	import { DEFAULT_FIAT_SYMBOL, exchangeStore } from '$lib/stores/exchangeRates'
+	import { defaultBlockchainNetwork } from '$lib/adapters/transaction'
 
 	export let message: DataMessage
 	export let users: User[]
@@ -52,6 +53,7 @@
 		const chatName =
 			chat?.name ?? users.find((u) => u.address !== userProfile.address)?.name ?? 'Unknown'
 		args = {
+			chainId: defaultBlockchainNetwork.chainId,
 			chatId,
 			objectId: message.objectId,
 			instanceId: message.instanceId,

--- a/src/lib/objects/external/iframe.svelte
+++ b/src/lib/objects/external/iframe.svelte
@@ -14,6 +14,7 @@
 	import adapters from '$lib/adapters'
 	import { walletStore } from '$lib/stores/wallet'
 	import { DEFAULT_FIAT_SYMBOL, exchangeStore } from '$lib/stores/exchangeRates'
+	import { defaultBlockchainNetwork } from '$lib/adapters/transaction'
 
 	// TODO: This needs escaping for the CSP
 	const getIframeSource = (object: LoadedObject): string => {
@@ -100,6 +101,7 @@
 		const iframeContextChange: IframeContextChange = {
 			type: 'iframe-context-change',
 			state: {
+				chainId: defaultBlockchainNetwork.chainId,
 				chatId,
 				chatName,
 				objectId,

--- a/src/lib/objects/index.d.ts
+++ b/src/lib/objects/index.d.ts
@@ -17,14 +17,14 @@ export interface WakuObjectAdapter {
 
 export type JSONPrimitive = string | number | boolean | null
 export type JSONObject = { [key: symbol]: JSONValue }
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface JSONArray extends Array<JSONValue> {}
+export type JSONArray = Array<JSONValue>
 
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray
 
 export type JSONSerializable = JSONValue
 
 export interface WakuObjectState {
+	readonly chainId: bigint
 	readonly chatId: string
 	readonly objectId: string
 	readonly instanceId: string

--- a/src/lib/objects/split/standalone.svelte
+++ b/src/lib/objects/split/standalone.svelte
@@ -123,6 +123,7 @@
 		{images}
 		{token}
 		{nativeToken}
+		chainId={args.chainId}
 		profile={args.profile}
 		chatName={args.chatName}
 		send={args.send}

--- a/src/lib/objects/split/views/summary.svelte
+++ b/src/lib/objects/split/views/summary.svelte
@@ -35,6 +35,7 @@
 	export let instanceId: string
 	export let token: Token
 	export let nativeToken: TokenAmount
+	export let chainId: bigint
 	export let send: (message: DataMessage) => Promise<void>
 	export let exitObject: () => void
 	export let getContract: GetContract
@@ -48,9 +49,16 @@
 		let splitContractAddress = splitterAddress
 
 		if (!splitContractAddress) {
-			fee = await estimateCreateSplitterContract(getContract, users)
+			fee = await estimateCreateSplitterContract(getContract, chainId, users)
 		}
-		fee += await estimateAddExpense(getContract, splitContractAddress, amnt, profile.address, users)
+		fee += await estimateAddExpense(
+			getContract,
+			chainId,
+			splitContractAddress,
+			amnt,
+			profile.address,
+			users,
+		)
 
 		return fee
 	}
@@ -65,7 +73,7 @@
 		try {
 			let splitContractAddress = splitterAddress
 			if (!splitContractAddress) {
-				splitContractAddress = await createSplitterContract(getContract, users)
+				splitContractAddress = await createSplitterContract(getContract, chainId, users)
 			}
 
 			let amnt = toBigInt(amount, token.decimals)

--- a/src/lib/objects/ui.svelte
+++ b/src/lib/objects/ui.svelte
@@ -13,6 +13,7 @@
 	import type { HDNodeWallet } from 'ethers/lib.commonjs'
 	import type { TokenAmount } from './schemas'
 	import { DEFAULT_FIAT_SYMBOL, exchangeStore } from '$lib/stores/exchangeRates'
+	import { defaultBlockchainNetwork } from '$lib/adapters/transaction'
 
 	export let objectId: string
 	export let instanceId: string
@@ -66,6 +67,7 @@
 			const chatName =
 				chat?.name ?? users.find((u) => u.address !== userProfile.address)?.name ?? 'Unknown'
 			args = {
+				chainId: defaultBlockchainNetwork.chainId,
 				chatId,
 				objectId,
 				instanceId,


### PR DESCRIPTION
Resolves #450

I decided to stor the `chainId` of the different chains into the `BlockchainNetwork` type because:

1. Getting the `chainId` is async call which makes the `args` creation a bit more challenging. Storing it in the `BlockchainNetwork` means we can just get it.
2. This way we can define the chains we want to connect to and then validate with the RPC that we are connected to the right chain. This is done in the main `Layout`.