### PR TITLE
feat: sets the right theme color (for iPhones)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,6 @@
 		<link rel="apple-touch-icon" href="/images/icons/icon-192x192.png" />
 		<link rel="manifest" href="/manifest.json" />
 		<meta name="msapplication-TileColor" content="#da532c" />
-		<meta name="theme-color" content="#ffffff" />
 		<meta
 			name="viewport"
 			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, viewport-fit=cover"

--- a/src/lib/stores/is-system-dark.ts
+++ b/src/lib/stores/is-system-dark.ts
@@ -1,0 +1,15 @@
+import { browser } from '$app/environment'
+import { readable } from 'svelte/store'
+
+export const isSystemDark = readable(false, (set) => {
+	if (!browser) {
+		return
+	}
+
+	const isDarkQuery = window.matchMedia('(prefers-color-scheme: dark)')
+	isDarkQuery.onchange = (event) => set(event.matches)
+
+	set(isDarkQuery.matches)
+
+	return () => (isDarkQuery.onchange = null)
+})

--- a/src/lib/stores/is-system-dark.ts
+++ b/src/lib/stores/is-system-dark.ts
@@ -1,15 +1,11 @@
 import { browser } from '$app/environment'
 import { readable } from 'svelte/store'
 
-export const isSystemDark = readable(false, (set) => {
-	if (!browser) {
-		return
-	}
+const isDarkQuery = browser && window.matchMedia('(prefers-color-scheme: dark)')
 
-	const isDarkQuery = window.matchMedia('(prefers-color-scheme: dark)')
-	isDarkQuery.onchange = (event) => set(event.matches)
-
-	set(isDarkQuery.matches)
-
-	return () => (isDarkQuery.onchange = null)
-})
+export const isSystemDark = !isDarkQuery
+	? readable(false)
+	: readable(isDarkQuery.matches, (set) => {
+			isDarkQuery.onchange = (event) => set(event.matches)
+			return () => (isDarkQuery.onchange = null)
+	  })

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -33,7 +33,6 @@ function createThemeStore(): ThemeStore {
 	const store = writable<Theme>({ darkMode, baseColor, isDarkMode: false })
 
 	isSystemDark.subscribe((isSystemDark) => {
-		console.log({ isSystemDark })
 		store.update((theme) => ({
 			...theme,
 			isDarkMode: isSystemDark && theme.darkMode === 'system',

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -1,6 +1,7 @@
 import { getFromLocalStorage, saveToLocalStorage } from '$lib/adapters/utils'
 import { writable, type Writable } from 'svelte/store'
 import { z } from 'zod'
+import { isSystemDark } from './is-system-dark'
 
 const darkModeSchema = z.enum(['dark', 'light', 'system'])
 export type DarkMode = z.infer<typeof darkModeSchema>
@@ -8,6 +9,7 @@ export type DarkMode = z.infer<typeof darkModeSchema>
 interface Theme {
 	darkMode: DarkMode
 	baseColor: string
+	isDarkMode: boolean
 }
 
 interface ThemeStore extends Writable<Theme> {
@@ -28,7 +30,15 @@ function createThemeStore(): ThemeStore {
 	} catch (error) {
 		// this is fine
 	}
-	const store = writable<Theme>({ darkMode, baseColor })
+	const store = writable<Theme>({ darkMode, baseColor, isDarkMode: false })
+
+	isSystemDark.subscribe((isSystemDark) => {
+		console.log({ isSystemDark })
+		store.update((theme) => ({
+			...theme,
+			isDarkMode: isSystemDark && theme.darkMode === 'system',
+		}))
+	})
 
 	return {
 		...store,

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -70,10 +70,9 @@ const lightColorsVars: Color[] = [
 	},
 ]
 
-export function changeColors(baseColor: string, darkMode: DarkMode, isSystemDark: boolean) {
+export function changeColors(baseColor: string, isDarkMode: boolean) {
 	if (!browser) return
 
-	const isDarkMode = darkMode === 'dark' || (darkMode === 'system' && isSystemDark)
 	const colors = isDarkMode ? darkColorVars : lightColorsVars
 	const colorsToRemove = isDarkMode ? lightColorsVars : darkColorVars
 
@@ -94,10 +93,4 @@ export function changeColors(baseColor: string, darkMode: DarkMode, isSystemDark
 		document.documentElement.style.removeProperty(name)
 		document.documentElement.style.removeProperty(`${name}-rgb`)
 	})
-
-	// Set theme color
-	const themeColorNode = document.querySelector('meta[name="theme-color"]') as HTMLMetaElement
-	if (themeColorNode) {
-		themeColorNode.content = isDarkMode ? '#000000' : '#ffffff'
-	}
 }

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -1,6 +1,5 @@
 import { getClosestColor, hexToRgb } from '@waku-objects/luminance'
 import { browser } from '$app/environment'
-import type { DarkMode } from '$lib/stores/theme'
 
 interface Color {
 	name: string

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -94,4 +94,10 @@ export function changeColors(baseColor: string, darkMode: DarkMode, isSystemDark
 		document.documentElement.style.removeProperty(name)
 		document.documentElement.style.removeProperty(`${name}-rgb`)
 	})
+
+	// Set theme color
+	const themeColorNode = document.querySelector('meta[name="theme-color"]') as HTMLMetaElement
+	if (themeColorNode) {
+		themeColorNode.content = isDarkMode ? '#000000' : '#ffffff'
+	}
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,9 +24,6 @@
 	let unsubscribeWalletStore: (() => void) | undefined = undefined
 	let unsubscribeExchangeStore: (() => void) | undefined = undefined
 	let loading = true
-	let error: string | undefined = undefined
-	let isDarkQuery: MediaQueryList
-	let isSystemDark: boolean | undefined
 
 	onMount(async () => {
 		unsubscribeWalletStore = walletStore.subscribe(({ wallet }) => {
@@ -60,11 +57,6 @@
 			})
 		}
 		loading = false
-
-		isDarkQuery = window.matchMedia('(prefers-color-scheme: dark)')
-		isDarkQuery.onchange = (event) => {
-			isSystemDark = event.matches
-		}
 	})
 
 	onDestroy(() => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -73,7 +73,7 @@
 		if (unsubscribeExchangeStore) unsubscribeExchangeStore()
 	})
 
-	$: changeColors($theme.baseColor, $theme.darkMode, isSystemDark ?? isDarkQuery?.matches)
+	$: changeColors($theme.baseColor, $theme.isDarkMode)
 
 	const resolveError =
 		(error: ErrorDescriptor, handler: () => Promise<void> | void) => async () => {
@@ -81,6 +81,10 @@
 			errorStore.resolve(error)
 		}
 </script>
+
+<svelte:head>
+	<meta name="theme-color" content={$theme.isDarkMode ? '#000000' : '#ffffff'} />
+</svelte:head>
 
 <div class="root">
 	{#if $errorStore.length > 0}


### PR DESCRIPTION
This should probably be refactored into a:
```html
<svelte:head>
	<meta name="theme-color" content={$theme.isDark ? 'black' : 'white'} />
</svelte:head>
```

The issue is that currently there's no easy way to listen to changed about which theme is actually being displayed. If it's the system theme and the system appearance changes, the store does not. The `isSystemDark` variable and listener from #482 should probably be moved to the store?