### PR TITLE
feat: external objects with URL and metadata check

### DIFF
--- a/src/lib/objects/external/iframe.svelte
+++ b/src/lib/objects/external/iframe.svelte
@@ -7,7 +7,7 @@
 	import template from './template.html?raw'
 
 	// Types
-	import { getNPMObject, type LoadedObject } from './lib'
+	import { getObject, type LoadedObject } from './lib'
 	import { makeIframeDispatcher, type IframeContextChange } from './dispatch'
 	import { postWindowMessage, registerWindow, unregisterWindow } from '.'
 	import { onDestroy } from 'svelte'
@@ -22,6 +22,7 @@
 		return template
 			.replace('__CSP__', object.csp)
 			.replace('__URL__', object.script)
+			.replace('__URL_INTEGRITY__', object.scriptIntegrity)
 			.replace('__CLASS__', object.className)
 	}
 
@@ -75,7 +76,7 @@
 	}
 
 	$: args &&
-		getNPMObject(args.objectId, message ? 'chat' : 'standalone').then((result) => (object = result))
+		getObject(args.objectId, message ? 'chat' : 'standalone').then((result) => (object = result))
 	$: if (iframe && iframe.contentWindow) {
 		registerWindow(args.instanceId, iframe.contentWindow)
 		updateContext()

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -1,3 +1,5 @@
+import { IPFS_GATEWAY } from '$lib/adapters/ipfs'
+
 // Not sure how inefficient this is
 const scripts = import.meta.glob('/node_modules/**/object/index.js', {
 	as: 'url',
@@ -14,14 +16,29 @@ export type Csp = {
 	'base-uri'?: string
 }
 
+export type WakuScriptType = 'chat' | 'standalone'
+
+export type WakuFile = {
+	path: string
+	hash: `sha256-${string}`
+}
+
+export type WakuFiles = {
+	logo: WakuFile
+	chat: WakuFile
+	standalone?: WakuFile
+}
+
 export type WakuObject = {
 	name: string
 	standalone?: boolean
 	csp: Csp
+	files: WakuFiles
 }
 
 export type LoadedObject = {
 	script: string
+	scriptIntegrity: `sha256-${string}` | null
 	csp: string
 	name: string
 	className: string
@@ -41,25 +58,66 @@ const formatCsp = (csp: Csp, add?: Csp): string => {
 		.join('; ')
 }
 
-export const getNPMObject = async (
-	module: string,
-	className: 'chat' | 'standalone',
+export const getNPMObject = async (module: string, type: WakuScriptType) => {
+	const object = (await objects[`/node_modules/${module}/object/metadata.json`]()) as WakuObject
+	const script = await scripts[
+		`/node_modules/${module}/object/${type === 'chat' ? 'index' : 'standalone'}.js`
+	]()
+
+	return { object, script, integrity: null }
+}
+
+export const getURLObject = async (url: string, type: WakuScriptType) => {
+	const object = (await (await fetch(`${url}/metadata.json`)).json()) as WakuObject
+	const file = object.files[type]
+
+	if (!file) {
+		throw new Error(`object does not include ${type} script`)
+	}
+
+	const { path, hash: integrity } = file
+	return { object, script: `${url}/${path}`, integrity }
+}
+
+export const getIPFSObject = async (cid: string, type: WakuScriptType) => {
+	const { object, script, integrity } = await getURLObject(`${IPFS_GATEWAY}/${cid}`, type)
+
+	// TODO: Validate metadata.json hash
+
+	return { object, script, integrity }
+}
+
+export const getObjectSpec = async (objectId: string, type: WakuScriptType) => {
+	if (objectId.startsWith('url:')) {
+		return getURLObject(objectId.substring(4), type)
+	}
+
+	if (objectId.startsWith('ipfs:')) {
+		return getIPFSObject(objectId.substring(5), type)
+	}
+
+	return getNPMObject(objectId, type)
+}
+
+export const getObject = async (
+	objectId: string,
+	type: WakuScriptType,
 ): Promise<LoadedObject | null> => {
 	try {
-		const object = (await objects[`/node_modules/${module}/object/metadata.json`]()) as WakuObject
-		const script = await scripts[`/node_modules/${module}/object/index.js`]()
+		const { object, script, integrity } = await getObjectSpec(objectId, type)
 
 		const added = { ...DEFAULT_CSP } as Csp
 		if (!added['script-src']) {
 			added['script-src'] = ''
 		}
-		added['script-src'] += ` ${script}`
+		added['script-src'] += ` '${integrity}'`
 
 		return {
 			script,
+			scriptIntegrity: integrity,
 			csp: formatCsp(object.csp, added),
 			name: object.name,
-			className,
+			className: type,
 		}
 	} catch (err) {
 		// TODO: shouldn't this throw?

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -31,6 +31,7 @@ export type WakuFiles = {
 
 export type WakuObject = {
 	name: string
+	description: string
 	standalone?: boolean
 	csp: Csp
 	files: WakuFiles
@@ -75,6 +76,12 @@ export const getURLObject = async (url: string, type: WakuScriptType) => {
 		throw new Error(`object does not include ${type} script`)
 	}
 
+	// Prepend the URL to all files
+	for (const [type, { path }] of Object.entries(object.files)) {
+		// @ts-expect-error TODO: Fix this
+		object.files[type as keyof WakuFiles].path = `${url}/${path}`
+	}
+
 	const { path, hash: integrity } = file
 	return { object, script: `${url}/${path}`, integrity }
 }
@@ -87,6 +94,7 @@ export const getIPFSObject = async (cid: string, type: WakuScriptType) => {
 	return { object, script, integrity }
 }
 
+// TODO: Figure out the ID part
 export const getObjectSpec = async (objectId: string, type: WakuScriptType) => {
 	if (objectId.startsWith('url:')) {
 		return getURLObject(objectId.substring(4), type)

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -39,7 +39,7 @@ export type WakuObject = {
 
 export type LoadedObject = {
 	script: string
-	scriptIntegrity: `sha256-${string}` | null
+	scriptIntegrity: `sha256-${string}`
 	csp: string
 	name: string
 	className: string
@@ -61,11 +61,14 @@ const formatCsp = (csp: Csp, add?: Csp): string => {
 
 export const getNPMObject = async (module: string, type: WakuScriptType) => {
 	const object = (await objects[`/node_modules/${module}/object/metadata.json`]()) as WakuObject
-	const script = await scripts[
-		`/node_modules/${module}/object/${type === 'chat' ? 'index' : 'standalone'}.js`
-	]()
+	const file = object.files[type]
 
-	return { object, script, integrity: null }
+	if (!file) {
+		throw new Error(`object does not include ${type} script`)
+	}
+
+	const script = await scripts[`/node_modules/${module}/object/${file.path}`]()
+	return { object, script, integrity: file.hash }
 }
 
 export const getURLObject = async (url: string, type: WakuScriptType) => {

--- a/src/lib/objects/external/lib.ts
+++ b/src/lib/objects/external/lib.ts
@@ -82,8 +82,8 @@ export const getURLObject = async (url: string, type: WakuScriptType) => {
 		object.files[type as keyof WakuFiles].path = `${url}/${path}`
 	}
 
-	const { path, hash: integrity } = file
-	return { object, script: `${url}/${path}`, integrity }
+	const { path: script, hash: integrity } = file
+	return { object, script, integrity }
 }
 
 export const getIPFSObject = async (cid: string, type: WakuScriptType) => {

--- a/src/lib/objects/external/standalone.svelte
+++ b/src/lib/objects/external/standalone.svelte
@@ -8,14 +8,14 @@
 
 	import type { WakuObjectArgs } from '..'
 	import IframeComponent from './iframe.svelte'
-	import { getNPMObject, type LoadedObject } from './lib'
+	import { getObject, type LoadedObject } from './lib'
 
 	// Exports
 	export let args: WakuObjectArgs
 
 	let object: LoadedObject | null
 
-	$: args && getNPMObject(args.objectId, 'standalone').then((result) => (object = result))
+	$: args && getObject(args.objectId, 'standalone').then((result) => (object = result))
 
 	// Utility function which makes it easier to handle history for closing the object
 	const exitObject = (depth: number) => () =>

--- a/src/lib/objects/external/template.html
+++ b/src/lib/objects/external/template.html
@@ -17,7 +17,7 @@
 	</head>
 	<body>
 		<div id="app" class="__CLASS__"></div>
-		<script type="module" src="__URL__"></script>
+		<script type="module" src="__URL__" integrity="__URL_INTEGRITY__"></script>
 		<!-- prettier-ignore -->
 		<script>
 			const postSize = () => {

--- a/src/lib/objects/lookup.ts
+++ b/src/lib/objects/lookup.ts
@@ -18,12 +18,6 @@ const preInstalledObjectList: WakuObjectSvelteDescriptor[] = [
 		sandboxMeta.description,
 		sandboxLogo,
 	),
-	getExternalDescriptor(
-		'url:https://unpkg.com/@waku-objects/sandbox-example@0.5.0/object',
-		'URL test',
-		sandboxMeta.description,
-		sandboxLogo,
-	),
 ]
 
 export function lookup(objectId: string): WakuObjectSvelteDescriptor | undefined {

--- a/src/lib/objects/lookup.ts
+++ b/src/lib/objects/lookup.ts
@@ -18,6 +18,12 @@ const preInstalledObjectList: WakuObjectSvelteDescriptor[] = [
 		sandboxMeta.description,
 		sandboxLogo,
 	),
+	getExternalDescriptor(
+		'url:https://unpkg.com/@waku-objects/sandbox-example@0.4.0/object',
+		'URL test',
+		sandboxMeta.description,
+		sandboxLogo,
+	),
 ]
 
 export function lookup(objectId: string): WakuObjectSvelteDescriptor | undefined {

--- a/src/lib/objects/lookup.ts
+++ b/src/lib/objects/lookup.ts
@@ -18,12 +18,6 @@ const preInstalledObjectList: WakuObjectSvelteDescriptor[] = [
 		sandboxMeta.description,
 		sandboxLogo,
 	),
-	getExternalDescriptor(
-		'url:https://unpkg.com/@waku-objects/sandbox-example@0.4.0/object',
-		'URL test',
-		sandboxMeta.description,
-		sandboxLogo,
-	),
 ]
 
 export function lookup(objectId: string): WakuObjectSvelteDescriptor | undefined {

--- a/src/lib/objects/lookup.ts
+++ b/src/lib/objects/lookup.ts
@@ -18,6 +18,12 @@ const preInstalledObjectList: WakuObjectSvelteDescriptor[] = [
 		sandboxMeta.description,
 		sandboxLogo,
 	),
+	getExternalDescriptor(
+		'url:https://unpkg.com/@waku-objects/sandbox-example@0.5.0/object',
+		'URL test',
+		sandboxMeta.description,
+		sandboxLogo,
+	),
 ]
 
 export function lookup(objectId: string): WakuObjectSvelteDescriptor | undefined {

--- a/src/routes/identity/+page.svelte
+++ b/src/routes/identity/+page.svelte
@@ -29,9 +29,12 @@
 	import { uploadPicture } from '$lib/adapters/ipfs'
 	import Avatar from '$lib/components/avatar.svelte'
 	import { errorStore } from '$lib/stores/error'
+	import { installedObjectStore } from '$lib/stores/installed-objects'
+	import { getObjectSpec } from '$lib/objects/external/lib'
 
 	let avatar = $profile.avatar
 	let name = $profile.name
+	let objectPath = ''
 
 	$: if ($profile.loading === false && !name && !avatar) {
 		name = $profile.name
@@ -92,6 +95,20 @@
 			saveProfileNow()
 			timer = undefined
 		}, 1000)
+	}
+
+	async function addObject() {
+		const { object } = await getObjectSpec(objectPath, 'chat')
+		installedObjectStore.update((state) => {
+			state.objects.set(objectPath, {
+				objectId: objectPath,
+				name: object.name,
+				description: object.description,
+				logo: object.files.logo.path,
+			})
+			return { ...state }
+		})
+		objectPath = ''
 	}
 
 	onDestroy(() => {
@@ -177,6 +194,10 @@
 				<Logout />
 				Disconnect identity from device
 			</Button>
+		</Container>
+		<Container align="center" gap={12} padX={24} padY={24}>
+			<InputField bind:value={objectPath} label="Object path" />
+			<Button on:click={addObject}>Add object</Button>
 		</Container>
 		<Spacer height={12} />
 	</AuthenticatedOnly>


### PR DESCRIPTION
Needs some rebasing and doesn't include the chat flow to add objects. Maybe some additional checks for IPFS should be added as well, but they would be redundant assuming we agree on the `metadata.json` format.

There's a missing piece that is checking the `metadata.json` signature, but that should also be done in the chat flow.

This PR also fixes the CSP security issue where the entrypoint needed to be specified with a URL rather than a hash. The fix was to add the `integrity` prop to the `<script>` tag. I haven't tried this on Firefox though, hopefully this didn't introduce an additional CSP bug.

An example object to be added through the form on the settings tab: `url:https://unpkg.com/@waku-objects/sandbox-example@0.5.0/object`.