### PR TITLE
feat: encryption with signatures

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -71,9 +71,7 @@ async function waku() {
 	const command = process.argv[3]
 	const restArgs = process.argv.slice(4)
 
-	const commands: Record<string, (...args: string[]) => Promise<void>> = {
-		doc,
-	}
+	const commands: Record<string, (...args: string[]) => Promise<void>> = {}
 
 	const fn = commands[command]
 	if (!fn) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,7 +18,6 @@ async function main() {
 		fund,
 		balance,
 		txinfo,
-		waku,
 	}
 
 	const fn = commands[command]
@@ -65,22 +64,6 @@ async function txinfo(hash: string) {
 	const receipt = await getTransactionReceipt(hash)
 
 	console.log({ tx, receipt })
-}
-
-async function waku() {
-	const command = process.argv[3]
-	const restArgs = process.argv.slice(4)
-
-	const commands: Record<string, (...args: string[]) => Promise<void>> = {}
-
-	const fn = commands[command]
-	if (!fn) {
-		throw `unknown command: ${command}\nUsage: cli waku ${Object.keys(commands).join('|')}`
-	}
-
-	await fn(...restArgs)
-
-	process.exit(0)
 }
 
 main().catch(console.error)

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,6 +18,7 @@ async function main() {
 		fund,
 		balance,
 		txinfo,
+		waku,
 	}
 
 	const fn = commands[command]
@@ -64,6 +65,24 @@ async function txinfo(hash: string) {
 	const receipt = await getTransactionReceipt(hash)
 
 	console.log({ tx, receipt })
+}
+
+async function waku() {
+	const command = process.argv[3]
+	const restArgs = process.argv.slice(4)
+
+	const commands: Record<string, (...args: string[]) => Promise<void>> = {
+		doc,
+	}
+
+	const fn = commands[command]
+	if (!fn) {
+		throw `unknown command: ${command}\nUsage: cli waku ${Object.keys(commands).join('|')}`
+	}
+
+	await fn(...restArgs)
+
+	process.exit(0)
 }
 
 main().catch(console.error)

--- a/src/lib/adapters/waku/codec.ts
+++ b/src/lib/adapters/waku/codec.ts
@@ -1,0 +1,33 @@
+import {
+	createEncoder as createWakuSymmetricEncoder,
+	createDecoder as createWakuSymmetricDecoder,
+} from '@waku/message-encryption/symmetric'
+import { getTopic, type ContentTopic } from './waku'
+import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
+import { type Hex, fixHex } from './crypto'
+
+function toHex(value: Uint8Array | Hex): Hex {
+	return typeof value === 'string' ? fixHex(value) : bytesToHex(value)
+}
+
+export function createSymmetricEncoder(options: {
+	contentTopic: ContentTopic
+	symKey: Uint8Array | Hex
+	sigPrivKey?: Uint8Array | Hex
+}) {
+	const contentTopic = getTopic(options.contentTopic, toHex(options.symKey))
+	return createWakuSymmetricEncoder({
+		...options,
+		contentTopic,
+		symKey: hexToBytes(options.symKey),
+		sigPrivKey: options.sigPrivKey ? hexToBytes(options.sigPrivKey) : undefined,
+	})
+}
+
+export function createSymmetricDecoder(options: {
+	contentTopic: ContentTopic
+	symKey: Uint8Array | Hex
+}) {
+	const contentTopic = getTopic(options.contentTopic, toHex(options.symKey))
+	return createWakuSymmetricDecoder(contentTopic, hexToBytes(options.symKey))
+}

--- a/src/lib/adapters/waku/crypto.test.ts
+++ b/src/lib/adapters/waku/crypto.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { hash, publicKeyToAddress, sign, signatureToPublicKey } from './crypto'
+import { publicKeyToAddress } from './crypto'
 
 const testPrivateKey = 'd195918969e09d9394c768e25b621eafc4c360117a9e1eebb0a68bfd53119ba4'
 const testCompressedPublicKey = '0374a6b1cea74a7a755396d8c62a3be4eb9098c7bb286dcdfc02ab93e7683c93f9'
 const testUncompressedPublicKey =
 	'0474a6b1cea74a7a755396d8c62a3be4eb9098c7bb286dcdfc02ab93e7683c93f99515f1cf8980e0cb25b6078113813d90d99303aaea1aa34c12805f8355768e21'
-const testAddress = publicKeyToAddress(testUncompressedPublicKey)
+const testAddress = '0x5018604b6fcfb992e48c102dcff8f9084a68b751'
 
 describe('publicKeyToAddress', () => {
 	it('calculates correct address for compressed public key', () => {
@@ -16,18 +16,5 @@ describe('publicKeyToAddress', () => {
 	it('calculates correct address for uncompressed public key', () => {
 		const address = publicKeyToAddress(testUncompressedPublicKey)
 		expect(address).toEqual(testAddress)
-	})
-})
-
-describe('sign', () => {
-	it('calculates signature', () => {
-		const message = 'hello'
-
-		const data = new TextEncoder().encode(message)
-		const signature = sign(testPrivateKey, data)
-		const messageHash = hash(data)
-		const recoveredPublicKey = signatureToPublicKey(signature, messageHash)
-
-		expect(recoveredPublicKey).toEqual(testCompressedPublicKey)
 	})
 })

--- a/src/lib/adapters/waku/crypto.test.ts
+++ b/src/lib/adapters/waku/crypto.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { publicKeyToAddress } from './crypto'
 
-const testPrivateKey = 'd195918969e09d9394c768e25b621eafc4c360117a9e1eebb0a68bfd53119ba4'
+// const testPrivateKey = 'd195918969e09d9394c768e25b621eafc4c360117a9e1eebb0a68bfd53119ba4'
 const testCompressedPublicKey = '0374a6b1cea74a7a755396d8c62a3be4eb9098c7bb286dcdfc02ab93e7683c93f9'
 const testUncompressedPublicKey =
 	'0474a6b1cea74a7a755396d8c62a3be4eb9098c7bb286dcdfc02ab93e7683c93f99515f1cf8980e0cb25b6078113813d90d99303aaea1aa34c12805f8355768e21'

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -3,15 +3,16 @@ import {
 	sign as nobleSign,
 	ProjectivePoint,
 	Signature,
+	getPublicKey,
 } from '@noble/secp256k1'
 import { keccak_256 } from '@noble/hashes/sha3'
 import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
 import { gcm } from '@noble/ciphers/aes'
 import { randomBytes } from '@noble/ciphers/webcrypto/utils'
 
-type Hex = string
+export type Hex = string
 
-function fixHex(h: Hex): Hex {
+export function fixHex(h: Hex): Hex {
 	if (h.startsWith('0x')) {
 		return h.slice(2)
 	}
@@ -53,6 +54,11 @@ export function publicKeyToAddress(publicKey: Hex): Hex {
 	return '0x' + keyHash.slice(-40)
 }
 
+export function compressPublicKey(publicKey: Hex | Uint8Array): Hex {
+	publicKey = typeof publicKey === 'string' ? fixHex(publicKey) : bytesToHex(publicKey)
+	return ProjectivePoint.fromHex(publicKey).toHex(true)
+}
+
 export function signatureToPublicKey(signature: Hex, messageHash: Hex): Hex {
 	const publicKey = Signature.fromCompact(fixHex(signature)).recoverPublicKey(fixHex(messageHash))
 	return publicKey.toHex(true)
@@ -62,4 +68,10 @@ export function sign(privateKey: Hex, data: Uint8Array): Hex {
 	const messageHash = hash(data)
 	const signature = nobleSign(messageHash, fixHex(privateKey))
 	return signature.toCompactHex()
+}
+
+export function privateKeyToPublicKey(privateKey: Hex | Uint8Array): Hex {
+	const privateKeyHex = typeof privateKey === 'string' ? fixHex(privateKey) : bytesToHex(privateKey)
+	const publicKeyBytes = getPublicKey(privateKeyHex)
+	return bytesToHex(publicKeyBytes)
 }

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -3,7 +3,6 @@ import {
 	sign as nobleSign,
 	ProjectivePoint,
 	Signature,
-	getPublicKey,
 } from '@noble/secp256k1'
 import { keccak_256 } from '@noble/hashes/sha3'
 import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
@@ -68,4 +67,5 @@ export function sign(privateKey: Hex, data: Uint8Array): Hex {
 	const messageHash = hash(data)
 	const signature = nobleSign(messageHash, fixHex(privateKey))
 	return signature.toCompactHex()
+
 }

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -69,9 +69,3 @@ export function sign(privateKey: Hex, data: Uint8Array): Hex {
 	const signature = nobleSign(messageHash, fixHex(privateKey))
 	return signature.toCompactHex()
 }
-
-export function privateKeyToPublicKey(privateKey: Hex | Uint8Array): Hex {
-	const privateKeyHex = typeof privateKey === 'string' ? fixHex(privateKey) : bytesToHex(privateKey)
-	const publicKeyBytes = getPublicKey(privateKeyHex)
-	return bytesToHex(publicKeyBytes)
-}

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -1,9 +1,4 @@
-import {
-	getSharedSecret as nobleGetSharedSecret,
-	sign as nobleSign,
-	ProjectivePoint,
-	Signature,
-} from '@noble/secp256k1'
+import { getSharedSecret as nobleGetSharedSecret, ProjectivePoint } from '@noble/secp256k1'
 import { keccak_256 } from '@noble/hashes/sha3'
 import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
 import { gcm } from '@noble/ciphers/aes'

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -67,5 +67,4 @@ export function sign(privateKey: Hex, data: Uint8Array): Hex {
 	const messageHash = hash(data)
 	const signature = nobleSign(messageHash, fixHex(privateKey))
 	return signature.toCompactHex()
-
 }

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -57,14 +57,3 @@ export function compressPublicKey(publicKey: Hex | Uint8Array): Hex {
 	publicKey = typeof publicKey === 'string' ? fixHex(publicKey) : bytesToHex(publicKey)
 	return ProjectivePoint.fromHex(publicKey).toHex(true)
 }
-
-export function signatureToPublicKey(signature: Hex, messageHash: Hex): Hex {
-	const publicKey = Signature.fromCompact(fixHex(signature)).recoverPublicKey(fixHex(messageHash))
-	return publicKey.toHex(true)
-}
-
-export function sign(privateKey: Hex, data: Uint8Array): Hex {
-	const messageHash = hash(data)
-	const signature = nobleSign(messageHash, fixHex(privateKey))
-	return signature.toCompactHex()
-}

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -289,8 +289,6 @@ export default class WakuAdapter implements Adapter {
 			ownPublicKey,
 			decoder,
 			async (message, decodedMessage) => {
-				console.debug('invite', { message, decodedMessage })
-
 				if (!this.checkMessageSignature(message, decodedMessage)) {
 					return
 				}
@@ -749,8 +747,6 @@ export default class WakuAdapter implements Adapter {
 
 		const storageProfile = await ws.decodeDoc<StorageProfile>(decodedMessage)
 
-		console.debug({ storageProfile, profilePublicKey, decoder })
-
 		return storageProfile
 	}
 
@@ -812,7 +808,6 @@ export default class WakuAdapter implements Adapter {
 			symKey: groupEncryptionKey,
 		})
 		const groupChat = await ws.getDoc<StorageChat>(decoder)
-		console.debug({ groupChat, groupChatId })
 		if (groupChat) {
 			const updatedGroupChat = await this.storageChatToChat(groupChatId, groupChat)
 			chats.updateChat(groupChatId, (chat) => ({
@@ -946,7 +941,6 @@ export default class WakuAdapter implements Adapter {
 
 	private checkMessageSignature(message: Message, decodedMessage: DecodedMessage): boolean {
 		if (!decodedMessage.signaturePublicKey) {
-			console.debug('missing signature')
 			return false
 		}
 

--- a/src/lib/adapters/waku/index.ts
+++ b/src/lib/adapters/waku/index.ts
@@ -47,9 +47,16 @@ import { balanceStore } from '$lib/stores/balances'
 import type { ContentTopic } from './waku'
 import { installedObjectStore } from '$lib/stores/installed-objects'
 import { errorStore } from '$lib/stores/error'
-import { getSharedSecret, hash } from './crypto'
+import { compressPublicKey, fixHex, getSharedSecret, hash } from './crypto'
 import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
 import { encrypt, decrypt } from './crypto'
+import {
+	createEciesDecoder,
+	createEciesEncoder,
+	createSymmetricDecoder,
+	createSymmetricEncoder,
+} from './codec'
+import type { DecodedMessage } from '@waku/message-encryption'
 
 const MAX_MESSAGES = 100
 
@@ -203,32 +210,48 @@ async function getDoc<T>(
 ): Promise<T | undefined> {
 	const id = hash(symKey)
 	const key = `${contentTopic}/${id}`
-	const encryptedKey = encryptStringToHex(key, symKey)
-	const value = localStorage.getItem(encryptedKey)
+	const hashedKey = hash(new TextEncoder().encode(key))
+	const value = localStorage.getItem(hashedKey)
+
 	if (value && value !== 'undefined') {
 		const decryptedValue = decryptHexToString(value, symKey)
 		return JSON.parse(decryptedValue) as T
 	}
 
-	const storeValue = await ws.getDoc<T>(contentTopic, symKey)
-	const json = JSON.stringify(storeValue)
+	const decoder = createSymmetricDecoder({ contentTopic, symKey })
+	const storeValue = await ws.getDoc<T>(decoder)
+	if (!storeValue) {
+		return
+	}
 
+	const json = JSON.stringify(storeValue)
 	const encryptedJson = encryptStringToHex(json, symKey)
-	localStorage.setItem(encryptedKey, encryptedJson)
+	localStorage.setItem(hashedKey, encryptedJson)
 
 	return storeValue
 }
 
-async function setDoc<T>(ws: Wakustore, contentTopic: ContentTopic, symKey: Uint8Array, doc: T) {
+async function setDoc<T>(
+	ws: Wakustore,
+	contentTopic: ContentTopic,
+	symKey: Uint8Array,
+	sigPrivKey: Uint8Array,
+	doc: T,
+) {
+	if (!doc) {
+		return
+	}
+
 	const id = hash(symKey)
 	const key = `${contentTopic}/${id}`
-	const encryptedKey = encryptStringToHex(key, symKey)
+	const hashedKey = hash(new TextEncoder().encode(key))
 	const json = JSON.stringify(doc)
 	const encryptedJson = encryptStringToHex(json, symKey)
 
-	localStorage.setItem(encryptedKey, encryptedJson)
+	localStorage.setItem(hashedKey, encryptedJson)
 
-	return await ws.setDoc<T>(contentTopic, symKey, doc)
+	const encoder = createSymmetricEncoder({ contentTopic, symKey, sigPrivKey })
+	return await ws.setDoc<T>(encoder, doc)
 }
 
 export default class WakuAdapter implements Adapter {
@@ -242,7 +265,7 @@ export default class WakuAdapter implements Adapter {
 		const ownPublicKey = wallet.signingKey.compressedPublicKey
 
 		const ownPublicEncryptionKey = hexToBytes(hash(ownPublicKey))
-		const ownPrivateEncryptionKey = hexToBytes(hash(wallet.privateKey))
+		const ownPrivateEncryptionKey = hexToBytes(hash(ownPrivateKey))
 
 		const ws = await this.makeWakustore()
 		const wakuObjectAdapter = makeWakuObjectAdapter(this, wallet)
@@ -263,27 +286,35 @@ export default class WakuAdapter implements Adapter {
 		chats.update((state) => ({ ...state, chats: new Map(storageChatEntries), loading: false }))
 
 		// subscribe to invites
-		const inviteKey = ownPublicEncryptionKey
-		await this.safeWaku.subscribe(inviteKey, undefined, async (message) => {
-			if (message.type !== 'invite') {
-				return
-			}
-
-			const chatEncryptionKey = getSharedSecret(ownPrivateKey, message.senderPublicKey)
-
-			const chatsMap = get(chats).chats
-			if (!chatsMap.has(chatEncryptionKey)) {
-				let user = await this.storageProfileToUser(message.senderPublicKey)
-				if (!user) {
-					user = {
-						publicKey: message.senderPublicKey,
-					}
+		const decoder = createEciesDecoder({ contentTopic: 'invites', privateKey: ownPrivateKey })
+		await this.safeWaku.subscribeEncrypted(
+			ownPublicKey,
+			decoder,
+			async (message, decodedMessage) => {
+				if (!this.checkMessageSignature(message, decodedMessage)) {
+					return
 				}
 
-				createPrivateChat(chatEncryptionKey, user, ownPublicKey)
-			}
-			await this.subscribeToPrivateChat(ownPublicKey, chatEncryptionKey, wakuObjectAdapter)
-		})
+				if (message.type !== 'invite') {
+					return
+				}
+
+				const chatEncryptionKey = getSharedSecret(ownPrivateKey, message.senderPublicKey)
+
+				const chatsMap = get(chats).chats
+				if (!chatsMap.has(chatEncryptionKey)) {
+					let user = await this.storageProfileToUser(message.senderPublicKey)
+					if (!user) {
+						user = {
+							publicKey: message.senderPublicKey,
+						}
+					}
+
+					createPrivateChat(chatEncryptionKey, user, ownPublicKey)
+				}
+				await this.subscribeToPrivateChat(ownPublicKey, chatEncryptionKey, wakuObjectAdapter)
+			},
+		)
 
 		// subscribe to chats
 		const allChats = Array.from(get(chats).chats)
@@ -334,13 +365,15 @@ export default class WakuAdapter implements Adapter {
 				ws,
 				'objects',
 				ownPrivateEncryptionKey,
+				hexToBytes(ownPrivateKey),
 				Array.from(objects.objects),
 			)
 		})
 		this.subscriptions.push(subscribeObjectStore)
 
 		// installed objects
-		const storageInstalledObjects = await ws.getDoc<StorageInstalledObjectEntry[]>(
+		const storageInstalledObjects = await getDoc<StorageInstalledObjectEntry[]>(
+			ws,
 			'installed',
 			ownPrivateEncryptionKey,
 		)
@@ -356,9 +389,11 @@ export default class WakuAdapter implements Adapter {
 				firstInstalledObjectStoreSave = false
 				return
 			}
-			await ws.setDoc<StorageInstalledObjectEntry[]>(
+			await setDoc<StorageInstalledObjectEntry[]>(
+				ws,
 				'installed',
 				ownPrivateEncryptionKey,
+				hexToBytes(ownPrivateKey),
 				Array.from(installed.objects),
 			)
 		})
@@ -378,10 +413,8 @@ export default class WakuAdapter implements Adapter {
 
 	async saveUserProfile(wallet: BaseWallet, name?: string, avatar?: string): Promise<void> {
 		const ownPublicKey = wallet.signingKey.compressedPublicKey
-		if (!ownPublicKey) {
-			throw 'wallet not found'
-		}
 		const ownPublicEncryptionKey = hexToBytes(hash(ownPublicKey))
+		const ownPrivateKey = wallet.privateKey
 
 		const defaultProfile: StorageProfile = { name: name ?? ownPublicKey }
 		const storageProfile = (await this.fetchStorageProfile(ownPublicKey)) || defaultProfile
@@ -391,7 +424,13 @@ export default class WakuAdapter implements Adapter {
 
 		if (avatar || name) {
 			const ws = await this.makeWakustore()
-			setDoc<StorageProfile>(ws, 'profile', ownPublicEncryptionKey, storageProfile)
+			setDoc<StorageProfile>(
+				ws,
+				'profile',
+				ownPublicEncryptionKey,
+				hexToBytes(ownPrivateKey),
+				storageProfile,
+			)
 			profile.update((state) => ({ ...state, name, avatar }))
 		}
 	}
@@ -417,8 +456,15 @@ export default class WakuAdapter implements Adapter {
 			chatId: ownPublicKey,
 		}
 
-		const inviteEncryptionKey = hexToBytes(hash(peerPublicKey))
-		await this.safeWaku.sendMessage(inviteMessage, inviteEncryptionKey)
+		// const inviteEncryptionKey = hexToBytes(hash(peerPublicKey))
+		// await this.safeWaku.sendMessage(inviteMessage, inviteEncryptionKey, hexToBytes(ownPrivateKey))
+		const ws = await this.makeWakustore()
+		const encoder = createEciesEncoder({
+			contentTopic: 'invites',
+			publicKey: peerPublicKey,
+			sigPrivKey: ownPrivateKey,
+		})
+		await ws.setDoc(encoder, inviteMessage)
 
 		const chatEncryptionKey = getSharedSecret(ownPrivateKey, peerPublicKey)
 		const joined = true
@@ -459,8 +505,13 @@ export default class WakuAdapter implements Adapter {
 
 		const ws = await this.makeWakustore()
 		const encryptionKey = hexToBytes(chatId)
-		console.debug({ encryptionKey, storageChat, chatId })
-		await ws.setDoc<StorageChat>('group-chats', encryptionKey, storageChat)
+		const privateKey = hexToBytes(wallet.privateKey)
+		const encoder = createSymmetricEncoder({
+			contentTopic: 'group-chats',
+			symKey: encryptionKey,
+			sigPrivKey: privateKey,
+		})
+		await ws.setDoc<StorageChat>(encoder, storageChat)
 
 		const ownPublicKey = wallet.signingKey.compressedPublicKey
 		await this.subscribeToGroupChat(ownPublicKey, chatId, wakuObjectAdapter)
@@ -471,8 +522,9 @@ export default class WakuAdapter implements Adapter {
 	async addMemberToGroupChat(chatId: string, users: string[]): Promise<void> {
 		const ws = await this.makeWakustore()
 		const encryptionKey = hexToBytes(chatId)
+		const decoder = createSymmetricDecoder({ contentTopic: 'group-chats', symKey: encryptionKey })
 
-		const groupChat = await ws.getDoc<StorageChat>('group-chats', encryptionKey)
+		const groupChat = await ws.getDoc<StorageChat>(decoder)
 		if (!groupChat) {
 			return
 		}
@@ -482,14 +534,26 @@ export default class WakuAdapter implements Adapter {
 
 		groupChat.users = uniqueUsers
 
-		await ws.setDoc<StorageChat>('group-chats', encryptionKey, groupChat)
+		const wallet = get(walletStore).wallet
+		if (!wallet) {
+			return
+		}
+
+		const privateKey = hexToBytes(wallet.privateKey)
+		const encoder = createSymmetricEncoder({
+			contentTopic: 'group-chats',
+			symKey: encryptionKey,
+			sigPrivKey: privateKey,
+		})
+		await ws.setDoc<StorageChat>(encoder, groupChat)
 	}
 
 	async removeFromGroupChat(chatId: string, address: string): Promise<void> {
 		const ws = await this.makeWakustore()
 		const encryptionKey = hexToBytes(chatId)
 
-		const groupChat = await ws.getDoc<StorageChat>('group-chats', encryptionKey)
+		const decoder = createSymmetricDecoder({ contentTopic: 'group-chats', symKey: encryptionKey })
+		const groupChat = await ws.getDoc<StorageChat>(decoder)
 		if (!groupChat) {
 			return
 		}
@@ -498,14 +562,26 @@ export default class WakuAdapter implements Adapter {
 			users: groupChat.users.filter((user) => user !== address),
 		}
 
-		await ws.setDoc<StorageChat>('group-chats', encryptionKey, updatedGroupChat)
+		const wallet = get(walletStore).wallet
+		if (!wallet) {
+			return
+		}
+
+		const privateKey = hexToBytes(wallet.privateKey)
+		const encoder = createSymmetricEncoder({
+			contentTopic: 'group-chats',
+			symKey: encryptionKey,
+			sigPrivKey: privateKey,
+		})
+		await ws.setDoc<StorageChat>(encoder, updatedGroupChat)
 	}
 
 	async saveGroupChatProfile(chatId: string, name?: string, avatar?: string): Promise<void> {
 		const ws = await this.makeWakustore()
 		const encryptionKey = hexToBytes(chatId)
 
-		const groupChat = await ws.getDoc<StorageChat>('group-chats', encryptionKey)
+		const decoder = createSymmetricDecoder({ contentTopic: 'group-chats', symKey: encryptionKey })
+		const groupChat = await ws.getDoc<StorageChat>(decoder)
 		if (!groupChat) {
 			return
 		}
@@ -513,11 +589,23 @@ export default class WakuAdapter implements Adapter {
 		groupChat.name = name ?? groupChat.name
 		groupChat.avatar = avatar ?? groupChat.avatar
 
-		await ws.setDoc<StorageChat>('group-chats', encryptionKey, groupChat)
+		const wallet = get(walletStore).wallet
+		if (!wallet) {
+			return
+		}
+
+		const privateKey = hexToBytes(wallet.privateKey)
+		const encoder = createSymmetricEncoder({
+			contentTopic: 'group-chats',
+			symKey: encryptionKey,
+			sigPrivKey: privateKey,
+		})
+		await ws.setDoc<StorageChat>(encoder, groupChat)
 	}
 
 	async sendChatMessage(wallet: BaseWallet, chatId: string, text: string): Promise<void> {
 		const senderPublicKey = wallet.signingKey.compressedPublicKey
+		const senderPrivateKey = wallet.privateKey
 		const message: Message = {
 			type: 'user',
 			timestamp: Date.now(),
@@ -527,7 +615,7 @@ export default class WakuAdapter implements Adapter {
 
 		const encryptionKey = hexToBytes(chatId)
 
-		await this.safeWaku.sendMessage(message, encryptionKey)
+		await this.safeWaku.sendMessage(message, encryptionKey, hexToBytes(senderPrivateKey))
 	}
 
 	async sendData(
@@ -538,6 +626,7 @@ export default class WakuAdapter implements Adapter {
 		data: JSONSerializable,
 	): Promise<void> {
 		const senderPublicKey = wallet.signingKey.compressedPublicKey
+		const senderPrivateKey = wallet.privateKey
 		const message: Message = {
 			type: 'data',
 			timestamp: Date.now(),
@@ -549,7 +638,7 @@ export default class WakuAdapter implements Adapter {
 
 		const encryptionKey = hexToBytes(chatId)
 
-		await this.safeWaku.sendMessage(message, encryptionKey)
+		await this.safeWaku.sendMessage(message, encryptionKey, hexToBytes(senderPrivateKey))
 	}
 
 	async sendGroupChatInvite(
@@ -566,10 +655,11 @@ export default class WakuAdapter implements Adapter {
 		}
 
 		const ownPrivateKey = wallet.privateKey
+		const sigPrivKey = hexToBytes(ownPrivateKey)
 		for (const userPublicKey of userPublicKeys) {
 			const chatEncryptionKey = hexToBytes(getSharedSecret(ownPrivateKey, userPublicKey))
 
-			await this.safeWaku.sendMessage(message, chatEncryptionKey)
+			await this.safeWaku.sendMessage(message, chatEncryptionKey, sigPrivKey)
 		}
 	}
 
@@ -633,7 +723,34 @@ export default class WakuAdapter implements Adapter {
 	private async fetchStorageProfile(profilePublicKey: string): Promise<StorageProfile | undefined> {
 		const ws = await this.makeWakustore()
 		const profileEncryptionKey = hexToBytes(hash(profilePublicKey))
-		const storageProfile = await ws.getDoc<StorageProfile>('profile', profileEncryptionKey)
+		const decoder = createSymmetricDecoder({
+			contentTopic: 'profile',
+			symKey: profileEncryptionKey,
+		})
+		const decodedMessage = await ws.getDecodedMessage(decoder)
+
+		if (!decodedMessage) {
+			console.error('missing document')
+			return
+		}
+
+		if (!decodedMessage.signaturePublicKey) {
+			console.error('missing signature', { decodedMessage })
+			return
+		}
+
+		if (compressPublicKey(decodedMessage.signaturePublicKey) !== fixHex(profilePublicKey)) {
+			console.error('invalid signature', {
+				decodedMessage,
+				profilePublicKey,
+				signaturePublicKey: bytesToHex(decodedMessage.signaturePublicKey),
+			})
+			return
+		}
+
+		const storageProfile = await ws.decodeDoc<StorageProfile>(decodedMessage)
+
+		console.debug({ storageProfile, profilePublicKey, decoder })
 
 		return storageProfile
 	}
@@ -691,7 +808,11 @@ export default class WakuAdapter implements Adapter {
 		const ws = await this.makeWakustore()
 
 		const groupEncryptionKey = hexToBytes(groupChatId)
-		const groupChat = await ws.getDoc<StorageChat>('group-chats', groupEncryptionKey)
+		const decoder = createSymmetricDecoder({
+			contentTopic: 'group-chats',
+			symKey: groupEncryptionKey,
+		})
+		const groupChat = await ws.getDoc<StorageChat>(decoder)
 		console.debug({ groupChat, groupChatId })
 		if (groupChat) {
 			const updatedGroupChat = await this.storageChatToChat(groupChatId, groupChat)
@@ -705,8 +826,28 @@ export default class WakuAdapter implements Adapter {
 		}
 
 		const groupChatSubscription = await ws.onSnapshot<StorageChat>(
-			ws.docQuery('group-chats', groupEncryptionKey),
-			async (groupChat) => {
+			ws.docQuery(decoder),
+			async (groupChat, decodedMessage) => {
+				// check if signed
+				if (!decodedMessage.signaturePublicKey) {
+					return
+				}
+
+				// check if the chat exists locally
+				const chat = get(chats).chats.get(groupChatId)
+				if (!chat) {
+					return
+				}
+
+				// check if the signature matches a member of the group
+				if (
+					!chat.users
+						.map((user) => user.publicKey)
+						.includes(bytesToHex(decodedMessage.signaturePublicKey))
+				) {
+					return
+				}
+
 				if (groupChat.users.includes(ownPublicKey)) {
 					const updatedGroupChat = await this.storageChatToChat(groupChatId, groupChat)
 					chats.updateChat(groupChatId, (chat) => ({
@@ -733,9 +874,21 @@ export default class WakuAdapter implements Adapter {
 		timeFilter?: TimeFilter,
 	) {
 		const encryptionKey = hexToBytes(chatId)
+		const decoder = createSymmetricDecoder({
+			contentTopic: 'private-message',
+			symKey: encryptionKey,
+		})
 
-		this.safeWaku.subscribe(encryptionKey, timeFilter, (message) =>
-			this.handleMessage(ownPublicKey, message, encryptionKey, wakuObjectAdapter),
+		this.safeWaku.subscribeEncrypted(
+			chatId,
+			decoder,
+			async (message, decodedMessage) => {
+				if (!this.checkMessageSignature(message, decodedMessage)) {
+					return
+				}
+				await this.handleMessage(ownPublicKey, message, encryptionKey, wakuObjectAdapter)
+			},
+			timeFilter,
 		)
 	}
 
@@ -792,6 +945,20 @@ export default class WakuAdapter implements Adapter {
 		await addMessageToChat(ownPublicKey, adapter, chatId, message, send)
 	}
 
+	private checkMessageSignature(message: Message, decodedMessage: DecodedMessage): boolean {
+		if (!decodedMessage.signaturePublicKey) {
+			console.debug('missing signature')
+			return false
+		}
+
+		if (compressPublicKey(decodedMessage.signaturePublicKey) !== fixHex(message.senderPublicKey)) {
+			console.error('invalid signature', { decodedMessage, message })
+			return false
+		}
+
+		return true
+	}
+
 	private async updateContactProfiles() {
 		// look for changes in users profile name and picture
 		const allContacts = Array.from(get(chats).chats).flatMap(([, chat]) => chat.users)
@@ -834,10 +1001,17 @@ export default class WakuAdapter implements Adapter {
 		const ws = await this.makeWakustore()
 		const chatData: ChatData = get(chats)
 
+		const wallet = get(walletStore).wallet
+		if (!wallet) {
+			return
+		}
+
+		const sigPrivKey = hexToBytes(wallet.privateKey)
 		const result = await setDoc<StorageChatEntry[]>(
 			ws,
 			'chats',
 			ownPrivateEncryptionKey,
+			sigPrivKey,
 			Array.from(chatData.chats),
 		)
 

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -43,7 +43,7 @@ export type ContentTopic =
 
 export type QueryResult = AsyncGenerator<Promise<DecodedMessage | undefined>[]>
 
-function getTopic(contentTopic: ContentTopic, id: string | '' = '') {
+export function getTopic(contentTopic: ContentTopic, id: string | '' = '') {
 	const topicApp = 'wakuplay.im'
 	const topicVersion = '1'
 	const topicEncoding = 'json'

--- a/src/lib/adapters/waku/waku.ts
+++ b/src/lib/adapters/waku/waku.ts
@@ -97,8 +97,6 @@ export async function storeDocument(waku: LightNode, encoder: IEncoder, document
 	const json = JSON.stringify(document)
 	const payload = utf8ToBytes(json)
 
-	console.debug('storeDocument', { encoder, document })
-
 	const sendResult = await waku.lightPush.send(encoder, { payload })
 	if (sendResult.errors && sendResult.errors.length > 0) {
 		return sendResult.errors

--- a/src/routes/group/chat/[id]/edit/+page.svelte
+++ b/src/routes/group/chat/[id]/edit/+page.svelte
@@ -33,6 +33,8 @@
 	import { userDisplayName } from '$lib/utils/user'
 	import { errorStore } from '$lib/stores/error'
 
+	$: console.log($chats)
+
 	$: chatId = $page.params.id
 	$: groupChat = $chats.chats.get(chatId)
 	let picture: string | undefined
@@ -185,9 +187,11 @@
 			</Container>
 			<ul class="chats" aria-label="Contact List">
 				{#each groupMembers as user}
-					{@const isContact = Array.from($chats.chats)
-						.map(([, chat]) => chat.chatId)
-						.includes(user.publicKey)}
+					{@const contactChat = Array.from($chats.chats)
+						.filter(([, chat]) => chat.type === 'private')
+						.map(([, chat]) => chat)
+						.find((chat) => chat.users.map((user) => user.publicKey).includes(user.publicKey))}
+					{@const isContact = !!contactChat}
 					{@const isMe = user.publicKey === wallet.signingKey.compressedPublicKey}
 					<li class={`${isContact ? 'contact' : 'not-contact'} ${isMe ? 'me' : ''}`}>
 						<div class="chat-button" role="listitem">
@@ -210,7 +214,7 @@
 											<UserFollow />
 										</Button>
 									{:else if isContact}
-										<Button variant="icon" on:click={() => goto(routes.CHAT(user.publicKey))}>
+										<Button variant="icon" on:click={() => goto(routes.CHAT(contactChat.chatId))}>
 											<ChatLaunch />
 										</Button>
 									{/if}

--- a/src/routes/invite/[address]/+page.svelte
+++ b/src/routes/invite/[address]/+page.svelte
@@ -65,7 +65,7 @@
 			errorStore.addEnd({
 				title: 'Connection error',
 				ok: true,
-				message: `Failed to load user profile. Datails: ${(error as Error)?.message}`,
+				message: `Failed to load user profile. Details: ${(error as Error)?.message}`,
 				retry: () => tryLoadCounterPartyProfile(),
 			})
 		}


### PR DESCRIPTION
**This is a breaking change**

Fixes some of the issues created by this PR: https://github.com/logos-innovation-lab/waku-objects-playground/pull/488
Basically this PR added signing and verification to the data and also changed the code to work with encrypted encoders/decoders as well.
Originally it also contained ECIES encryption but that does not work at the moment in js-waku: https://github.com/waku-org/js-waku/issues/1716