### PR TITLE
feat: invite with ECIES

### DIFF
--- a/src/lib/adapters/waku/codec.ts
+++ b/src/lib/adapters/waku/codec.ts
@@ -2,9 +2,13 @@ import {
 	createEncoder as createWakuSymmetricEncoder,
 	createDecoder as createWakuSymmetricDecoder,
 } from '@waku/message-encryption/symmetric'
+import {
+	createEncoder as createWakuEciesEncoder,
+	createDecoder as createWakuEciesDecoder,
+} from '@waku/message-encryption/ecies'
 import { getTopic, type ContentTopic } from './waku'
 import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
-import { type Hex, fixHex } from './crypto'
+import { type Hex, fixHex, uncompressPublicKey, privateKeyToPublicKey } from './crypto'
 
 function toHex(value: Uint8Array | Hex): Hex {
 	return typeof value === 'string' ? fixHex(value) : bytesToHex(value)
@@ -30,4 +34,27 @@ export function createSymmetricDecoder(options: {
 }) {
 	const contentTopic = getTopic(options.contentTopic, toHex(options.symKey))
 	return createWakuSymmetricDecoder(contentTopic, hexToBytes(options.symKey))
+}
+
+export function createEciesEncoder(options: {
+	contentTopic: ContentTopic
+	publicKey: Uint8Array | Hex
+	sigPrivKey?: Uint8Array | Hex
+}) {
+	const contentTopic = getTopic(options.contentTopic, toHex(options.publicKey))
+	return createWakuEciesEncoder({
+		...options,
+		contentTopic,
+		publicKey: hexToBytes(uncompressPublicKey(options.publicKey)),
+		sigPrivKey: options.sigPrivKey ? hexToBytes(options.sigPrivKey) : undefined,
+	})
+}
+
+export function createEciesDecoder(options: {
+	contentTopic: ContentTopic
+	privateKey: Uint8Array | Hex
+}) {
+	const publicKey = privateKeyToPublicKey(options.privateKey)
+	const contentTopic = getTopic(options.contentTopic, toHex(publicKey))
+	return createWakuEciesDecoder(contentTopic, hexToBytes(options.privateKey))
 }

--- a/src/lib/adapters/waku/crypto.test.ts
+++ b/src/lib/adapters/waku/crypto.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { publicKeyToAddress } from './crypto'
+import {
+	compressPublicKey,
+	privateKeyToPublicKey,
+	publicKeyToAddress,
+	uncompressPublicKey,
+} from './crypto'
 
-// const testPrivateKey = 'd195918969e09d9394c768e25b621eafc4c360117a9e1eebb0a68bfd53119ba4'
+const testPrivateKey = 'd195918969e09d9394c768e25b621eafc4c360117a9e1eebb0a68bfd53119ba4'
 const testCompressedPublicKey = '0374a6b1cea74a7a755396d8c62a3be4eb9098c7bb286dcdfc02ab93e7683c93f9'
 const testUncompressedPublicKey =
 	'0474a6b1cea74a7a755396d8c62a3be4eb9098c7bb286dcdfc02ab93e7683c93f99515f1cf8980e0cb25b6078113813d90d99303aaea1aa34c12805f8355768e21'
@@ -16,5 +21,24 @@ describe('publicKeyToAddress', () => {
 	it('calculates correct address for uncompressed public key', () => {
 		const address = publicKeyToAddress(testUncompressedPublicKey)
 		expect(address).toEqual(testAddress)
+	})
+})
+
+describe('public key compression', () => {
+	it('calculates compressed public key', () => {
+		const result = compressPublicKey(testUncompressedPublicKey)
+		expect(result).toEqual(testCompressedPublicKey)
+	})
+
+	it('calculates uncompressed public key', () => {
+		const result = uncompressPublicKey(testCompressedPublicKey)
+		expect(result).toEqual(testUncompressedPublicKey)
+	})
+})
+
+describe('privateKeyToPublicKey', () => {
+	it('returns the public key', () => {
+		const publicKey = privateKeyToPublicKey(testPrivateKey)
+		expect(publicKey).toEqual(testCompressedPublicKey)
 	})
 })

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -1,4 +1,8 @@
-import { getSharedSecret as nobleGetSharedSecret, ProjectivePoint } from '@noble/secp256k1'
+import {
+	getPublicKey,
+	getSharedSecret as nobleGetSharedSecret,
+	ProjectivePoint,
+} from '@noble/secp256k1'
 import { keccak_256 } from '@noble/hashes/sha3'
 import { sha256 as nobleSha256 } from '@noble/hashes/sha256'
 import { bytesToHex, hexToBytes } from '@waku/utils/bytes'
@@ -61,4 +65,15 @@ export function publicKeyToAddress(publicKey: Hex): Hex {
 export function compressPublicKey(publicKey: Hex | Uint8Array): Hex {
 	publicKey = typeof publicKey === 'string' ? fixHex(publicKey) : bytesToHex(publicKey)
 	return ProjectivePoint.fromHex(publicKey).toHex(true)
+}
+
+export function uncompressPublicKey(publicKey: Hex | Uint8Array): Hex {
+	publicKey = typeof publicKey === 'string' ? fixHex(publicKey) : bytesToHex(publicKey)
+	return ProjectivePoint.fromHex(publicKey).toHex(false)
+}
+
+export function privateKeyToPublicKey(privateKey: Hex | Uint8Array): Hex {
+	privateKey = typeof privateKey === 'string' ? fixHex(privateKey) : bytesToHex(privateKey)
+	const publicKeyBytes = getPublicKey(privateKey)
+	return bytesToHex(publicKeyBytes)
 }


### PR DESCRIPTION
This PR is based on #495, so that needs to be merged first.

This PR changes the invite to use ECIES instead of a symmetric key so it hides the information for a third-party who sent an invite. So for example if `A` sends an invite to `B` and `C` is already a contact of `B` then previously `C` could see who sent an invite to `B`. After this PR `C` will not know who sent an invite, the only information they can gather is that someone sent an invite. That may be addressed if the invite address is different from the public key and is changed periodically, but that is not part of this PR.