### PR TITLE
fix: group chat editing

### DIFF
--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -83,6 +83,6 @@ export function privateKeyToPublicKey(privateKey: Hex | Uint8Array): Hex {
 	return bytesToHex(publicKeyBytes)
 }
 
-export function arePublicKeysEqual(pkA: Hex, pkB: Hex): boolean {
-	return fixHex(pkA) === fixHex(pkB)
+export function arePublicKeysEqual(pkA: Hex | Uint8Array, pkB: Hex | Uint8Array): boolean {
+	return compressPublicKey(pkA) === compressPublicKey(pkB)
 }

--- a/src/lib/adapters/waku/crypto.ts
+++ b/src/lib/adapters/waku/crypto.ts
@@ -82,3 +82,7 @@ export function privateKeyToPublicKey(privateKey: Hex | Uint8Array): Hex {
 	const publicKeyBytes = getPublicKey(privateKey)
 	return bytesToHex(publicKeyBytes)
 }
+
+export function arePublicKeysEqual(pkA: Hex, pkB: Hex): boolean {
+	return fixHex(pkA) === fixHex(pkB)
+}

--- a/src/routes/group/chat/[id]/edit/+page.svelte
+++ b/src/routes/group/chat/[id]/edit/+page.svelte
@@ -33,8 +33,6 @@
 	import { userDisplayName } from '$lib/utils/user'
 	import { errorStore } from '$lib/stores/error'
 
-	$: console.log($chats)
-
 	$: chatId = $page.params.id
 	$: groupChat = $chats.chats.get(chatId)
 	let picture: string | undefined


### PR DESCRIPTION
There was an issue that the group chat name and photo was not editable, it always changed back to the original.

This PR fixes that. The root cause of the issue was that when checking the signature we compared the uncompressed public key (which was returned from the signature) with the compressed signature that we store and therefore the check failed.

There is another issue that the `ethers` package uses public keys with `0x` prefix, where the `@noble/crypto` package uses public keys without the `0x` prefix. I added a helper function for comparison (`arePublicKeysEqual`) but unfortunately that only works with direct comparison and therefore less useful when using with arrays (e.g. `includes`).