### PR TITLE
fix: babbles messages

### DIFF
--- a/src/routes/babbles/chat/[id]/[[thread_id]]/+page.svelte
+++ b/src/routes/babbles/chat/[id]/[[thread_id]]/+page.svelte
@@ -38,6 +38,8 @@
 	$: chatMessages = $chats.chats.get($page.params.id)?.messages || []
 	$: displayMessages = convertMessagesToThreaded(chatMessages)
 
+	$: console.debug({ chatMessages, displayMessages })
+
 	beforeUpdate(() => {
 		autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 74
 	})

--- a/src/routes/babbles/chat/[id]/[[thread_id]]/+page.svelte
+++ b/src/routes/babbles/chat/[id]/[[thread_id]]/+page.svelte
@@ -38,8 +38,6 @@
 	$: chatMessages = $chats.chats.get($page.params.id)?.messages || []
 	$: displayMessages = convertMessagesToThreaded(chatMessages)
 
-	$: console.debug({ chatMessages, displayMessages })
-
 	beforeUpdate(() => {
 		autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 74
 	})
@@ -128,6 +126,9 @@
 
 			const parentMessage = parentMap.get(message.parentId)
 			if (!parentMessage) {
+				// this is a workaround for the case when the parent is lost to
+				// keep the rest of the thread
+				roots.push(parent)
 				continue
 			}
 


### PR DESCRIPTION
Sometimes messages disappear from the waku store. This is a fix for the case if a message's parent is lost to keep at least the rest of the thread.